### PR TITLE
feat: 新增預約相關模型及其關聯

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ ehthumbs.db
 .env.development.local
 .env.test.local
 .env.production.local
+.venv/
 
 # Python
 __pycache__/

--- a/backend/pet_booking/reservations/models.py
+++ b/backend/pet_booking/reservations/models.py
@@ -1,3 +1,73 @@
 from django.db import models
+from users.models import Users
 
-# Create your models here.
+class Reservation_grooming(models.Model):
+    reservation_id = models.CharField(max_length=20)
+    store_name = models.CharField(max_length=50)
+    user_name = models.CharField(max_length=20)
+    user_phone = models.CharField(max_length=15)
+    grooming_services_name = models.IntegerField()
+    pet_name = models.CharField(max_length=10)
+    pet_breed = models.CharField(max_length=10)
+    pick_up_service = models.BooleanField()
+    reservation_time = models.DateTimeField()
+    customer_note = models.TextField()
+    store_note = models.TextField()
+    status = models.CharField(max_length=20, default='pending')
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+class Grooming_schedules(models.Model):
+    reservation_grooming = models.ForeignKey(
+        Reservation_grooming,
+        on_delete = models.CASCADE,
+        db_column = 'reservation_grooming_id'
+    )
+
+    date = models.DateField()
+    unavailable_time = models.TimeField()
+
+class Reservation_boarding(models.Model):
+    reservation_id = models.CharField(max_length=20)
+    store_name = models.CharField(max_length=50)
+    user_name = models.CharField(max_length=20)
+    user_phone = models.CharField(max_length=15)
+    pet_name = models.CharField(max_length=10)
+    room_type = models.CharField(max_length=20)
+    checkin_date = models.DateTimeField()
+    checkout_date = models.DateTimeField()
+    customer_note = models.TextField()
+    store_note = models.TextField()
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+class Boarding_schedules(models.Model):
+    reservation_boarding = models.ForeignKey(
+        Reservation_boarding,
+        on_delete = models.CASCADE,
+        db_column = 'reservation_boarding_id'
+    )
+
+class Orders(models.Model):
+    reservation_grooming = models.ForeignKey(
+        Reservation_grooming,
+        on_delete = models.CASCADE,
+        db_column = 'reservation_grooming_id',
+        null = True,
+        blank = True
+    )
+
+    reservation_boarding = models.ForeignKey(
+        Reservation_boarding,
+        on_delete = models.CASCADE,
+        db_column = 'reservation_boarding_id',
+        null = True,
+        blank = True
+    )
+
+    user_id = models.ForeignKey(
+        Users,
+        on_delete = models.CASCADE,
+        db_column = 'user_id'
+    )
+    total_price = models.IntegerField()


### PR DESCRIPTION
新增預約與排程模型：

新增 Reservation_grooming 模型，用於儲存美容預約的詳細資訊，包括使用者與寵物資料、服務類型及預約狀態。

新增 Grooming_schedules 模型，用於追蹤特定美容預約的不可用時段。

新增 Reservation_boarding 模型，用於儲存寄宿預約的詳細資訊，包括使用者、寵物、房型，以及入住與退房日期。

新增 Boarding_schedules 模型，用於管理寄宿預約的時程安排。

訂單管理：

新增 Orders 模型，將美容與寄宿預約與使用者關聯，並儲存每筆訂單的總金額資訊。