### PR TITLE
feat: 新增使用者與顧客資料模型，並設置自定義使用者模型與應用設定

### DIFF
--- a/backend/pet_booking/customers/apps.py
+++ b/backend/pet_booking/customers/apps.py
@@ -3,4 +3,4 @@ from django.apps import AppConfig
 
 class CustomersConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
-    name = "customers"
+    name = "pet_booking.customers"

--- a/backend/pet_booking/customers/models.py
+++ b/backend/pet_booking/customers/models.py
@@ -1,3 +1,78 @@
 from django.db import models
+from django.conf import settings
 
 # Create your models here.
+
+class Gender(models.TextChoices):
+    MALE = 'male', '男'
+    FEMALE = 'female', '女'
+
+class Species(models.TextChoices):
+    CAT = 'cat', '貓'
+    DOG = 'dog', '狗'
+
+class CustomersProfile(models.Model):
+    id = models.AutoField(primary_key=True)
+    user_id = models.ForeignKey('users.User', to_field='user_id', on_delete=models.CASCADE, db_index=True, related_name='customersProfiles')
+    full_name = models.CharField(max_length=255, null=False, blank=False)
+    gender = models.CharField(max_length=6, choices=Gender.choices, null=True, blank=True)
+    # birthday = models.DateField(null=True, blank=True)
+    phone = models.CharField(max_length=20, null=True, blank=True)
+    email = models.EmailField(null=False, blank=False)
+    address = models.CharField(max_length=512, null=True, blank=True)
+
+    class Meta:
+        db_table = 'customers_profile'
+
+    def __str__(self):
+        return f"{self.full_name} ({self.email})"
+
+
+class LikeStore(models.Model):
+    id = models.AutoField(primary_key=True)
+    user_id = models.ForeignKey('users.User', to_field='user_id', on_delete=models.CASCADE, db_index=True, related_name='likeStores')
+    store_id = models.ForeignKey('stores.Store', on_delete=models.CASCADE)
+
+    class Meta:
+        db_table = 'like_store'
+        # 為 user_id + store_id 組合建立唯一約束，避免重複喜愛同一家店（如需要）
+        unique_together = ('user_id', 'store_id')
+
+    def __str__(self):
+        return f"User {self.user_id} likes Store {self.stores.store_name}"
+
+class TernaryAnswer(models.TextChoices):
+    YES = 'yes', '是'
+    NO = 'no', '否'
+    UNCERTAIN = 'uncertain', '不確定'
+
+class Pet(models.Model):
+    user_id = models.ForeignKey('users.User', to_field='user_id', on_delete=models.CASCADE, db_index=True, related_name='pets')
+    species = models.CharField(max_length=4, choices=Species.choices, null=False, blank=False)
+    name = models.CharField(max_length=255, null=False, blank=False)
+    gender = models.CharField(max_length=6, choices=Gender.choices, null=False, blank=False)
+    breed = models.CharField(max_length=255, null=True, blank=True)
+    # birthday = models.DateField(null=True, blank=True)
+    age = models.IntegerField(null=True, blank=True)
+    weight = models.FloatField(null=True, blank=True)
+    spayed_or_neutered = models.CharField(max_length=10,
+        choices=TernaryAnswer.choices,
+        default=TernaryAnswer.UNCERTAIN,
+        null=True,
+        blank=True)
+    microchip = models.CharField(max_length=10,
+        choices=TernaryAnswer.choices,
+        default=TernaryAnswer.UNCERTAIN,
+        null=True,
+        blank=True)
+    last_deworming_date = models.DateField(null=True, blank=True)
+    last_vaccine_date = models.DateField(null=True, blank=True)
+    notes = models.TextField(null=True, blank=True)
+    image_url = models.ImageField(upload_to='pet_images/', null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = 'pets'
+
+    def __str__(self):
+        return f"{self.name} ({self.species}) owned by User {self.user_id}"

--- a/backend/pet_booking/settings.py
+++ b/backend/pet_booking/settings.py
@@ -120,3 +120,5 @@ STATIC_URL = "static/"
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+AUTH_USER_MODEL = 'users.User'

--- a/backend/pet_booking/users/apps.py
+++ b/backend/pet_booking/users/apps.py
@@ -3,4 +3,4 @@ from django.apps import AppConfig
 
 class UsersConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
-    name = "users"
+    name = "pet_booking.users"

--- a/backend/pet_booking/users/models.py
+++ b/backend/pet_booking/users/models.py
@@ -1,3 +1,43 @@
+# users/models.py
+import time
 from django.db import models
+from django.contrib.auth.models import AbstractUser
 
 # Create your models here.
+
+class UserRole(models.TextChoices):
+    MEMBER = 'member', '一般會員'   
+    STORE = 'store', '寵物業者'
+    ADMIN = 'admin', '系統管理者'
+
+class User(AbstractUser):
+    user_id = models.CharField(max_length=64, blank=True, null=True)
+    role = models.CharField(max_length=64, choices=UserRole.choices, default=UserRole.MEMBER, blank=False, verbose_name="用戶角色")
+    is_store_owner = models.BooleanField(default=False, blank=False, null=False, verbose_name="是否為寵物業者")
+    is_admin = models.BooleanField(default=False, blank=False, null=False, verbose_name="是否為系統管理者")
+    created_at = models.DateTimeField(auto_now_add=True, verbose_name="建立時間")
+    updated_at = models.DateTimeField(auto_now=True, verbose_name="更新時間")
+
+    USERNAME_FIELD = 'username'
+    REQUIRED_FIELDS = []
+
+    ROLE_PREFIX = {
+        'member': 'M',
+        'store': 'S',
+        'admin': 'A',
+    }
+
+    def save(self, *args, **kwargs):
+        if not self.user_id and self.role:
+            prefix = self.ROLE_PREFIX.get(self.role, 'X')  # 如果沒找到對應角色，給預設字母 X
+            now_timestamp = int(time.time())
+            self.user_id = f"{prefix}{now_timestamp}"
+        super().save(*args, **kwargs)
+
+    class Meta:
+        verbose_name = "用戶"
+        verbose_name_plural = "用戶"
+        db_table = 'users'
+
+    def __str__(self):
+        return f"{self.username}-{self.role}"

--- a/backend/pet_booking/users/models.py
+++ b/backend/pet_booking/users/models.py
@@ -11,7 +11,7 @@ class UserRole(models.TextChoices):
     ADMIN = 'admin', '系統管理者'
 
 class User(AbstractUser):
-    user_id = models.CharField(max_length=64, blank=True, null=True)
+    user_id = models.CharField(max_length=64, blank=True, null=True, unique=True)
     role = models.CharField(max_length=64, choices=UserRole.choices, default=UserRole.MEMBER, blank=False, verbose_name="用戶角色")
     is_store_owner = models.BooleanField(default=False, blank=False, null=False, verbose_name="是否為寵物業者")
     is_admin = models.BooleanField(default=False, blank=False, null=False, verbose_name="是否為系統管理者")


### PR DESCRIPTION
使用者與驗證模型強化：
在 users/models.py 中新增自定義 User 模型，加入以下功能與欄位：

使用者角色分類（member、store、admin）

自定義 user_id 產生邏輯

額外的欄位以支援使用者管理功能

使用 UserRole 類別統一定義角色選項

在 settings.py 中設置 AUTH_USER_MODEL = 'users.User'，使 Django 將此自定義模型作為預設使用者模型使用

顧客與寵物領域模型：
在 customers/models.py 中新增以下模型：

CustomersProfile：儲存顧客個人資料

LikeStore：記錄顧客喜歡的商店，並設有唯一性限制避免重複

Pet：詳細描述顧客所擁有的寵物資訊

並新增列舉型別（Gender、Species、TernaryAnswer）以統一資料表現