### PR TITLE
feat: 新增寄宿服務與美容服務的 API 功能，支持批量創建定價

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,9 @@
 {
-    "github.copilot.chat.commitMessageGeneration.instructions": [
-        {
-            "file": ".copilot-commit-message-instructions.md"
-        }
-    ]
+  "github.copilot.chat.commitMessageGeneration.instructions": [
+    {
+      "file": ".copilot-commit-message-instructions.md"
+    }
+  ],
+  "python-envs.defaultEnvManager": "ms-python.python:system",
+  "python-envs.pythonProjects": []
 }

--- a/backend/pet_booking/services/serializers.py
+++ b/backend/pet_booking/services/serializers.py
@@ -7,21 +7,36 @@ class BoardingServicePricingSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 class BoardingServiceSerializer(serializers.ModelSerializer):
-    pricings = BoardingServicePricingSerializer(source='boardingservicepricing_set',many=True, read_only=True)
+    pricings = BoardingServicePricingSerializer(source='boardingservicepricing_set', many=True)
 
     class Meta:
         model = BoardingService
         fields = ['id', 'store_id', 'cleaning_frequency', 'introduction', 'created_at', 'updated_at', 'pricings']
 
+    def create(self, validated_data):
+        pricings_data = validated_data.pop('pricings')
+        service = BoardingService.objects.create(**validated_data)
+        for pricing_data in pricings_data:
+            BoardingServicePricing.objects.create(boarding_service_id=service, **pricing_data)
+        return service
 
+  
 class GroomingServicePricingSerializer(serializers.ModelSerializer):
     class Meta:
         model = GroomingServicePricing
         fields = '__all__'
 
 class GroomingServiceSerializer(serializers.ModelSerializer):
-    pricings = GroomingServicePricingSerializer(source='groomingservicepricing_set', many=True, read_only=True)
+    pricings = GroomingServicePricingSerializer(source='groomingservicepricing_set', many=True)
 
     class Meta:
         model = GroomingService
         fields = ['id', 'store_id', 'service_title', 'introduction', 'notice', 'duration_minutes_min', 'duration_minutes_max', 'created_at', 'updated_at', 'pricings']
+
+    def create(self, validated_data):
+        pricings_data = validated_data.pop('pricings')
+        service = GroomingService.objects.create(**validated_data)
+        for pricing_data in pricings_data:
+            GroomingServicePricing.objects.create(grooming_service_id=service, **pricing_data)
+        return service
+    

--- a/backend/pet_booking/services/views.py
+++ b/backend/pet_booking/services/views.py
@@ -1,3 +1,25 @@
-from django.shortcuts import render
+from rest_framework import viewsets
+from .models import BoardingService, GroomingService, BoardingServicePricing, GroomingServicePricing
+from .serializers import BoardingServiceSerializer, GroomingServiceSerializer, BoardingServicePricingSerializer, GroomingServicePricingSerializer
+from rest_framework.permissions import IsAuthenticated
 
 # Create your views here.
+class BoardingServiceViewSet(viewsets.ModelViewSet):
+    queryset = BoardingService.objects.all()
+    serializer_class = BoardingServiceSerializer
+    # permission_classes = [IsAuthenticated]
+
+class BoardingServicePricingViewset(viewsets.ModelViewSet):
+    queryset = BoardingServicePricing.objects.all()
+    serializer_class = BoardingServicePricingSerializer
+    # permission_classes = [IsAuthenticated]
+
+class GroomingServiceViewSet(viewsets.ModelViewSet):
+    queryset = GroomingService.objects.all()
+    serializer_class = GroomingServiceSerializer
+    # permission_classes = [IsAuthenticated]
+
+class GroomingServicePricingViewset(viewsets.ModelViewSet):
+    queryset = GroomingServicePricing.objects.all()
+    serializer_class = GroomingServicePricingSerializer
+    # permission_classes = [IsAuthenticated]

--- a/backend/pet_booking/urls.py
+++ b/backend/pet_booking/urls.py
@@ -25,7 +25,7 @@ urlpatterns = [
     path('api/token/verify/', TokenVerifyView.as_view(), name='token_verify'),
     path('api/token/blacklist/', TokenBlacklistView.as_view(), name='token_blacklist'),
     path('o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
-
+]
 
 router = DefaultRouter(trailing_slash=False)
 router.register(r'store/profile', StoreProfileViewSet, basename='store-profile')
@@ -33,7 +33,10 @@ router.register(r'admin/stores', StoreAdminViewSet, basename='admin-stores')
 router.register(r'store/posts', StorePostViewSet, basename='store-posts')
 router.register(r'admin/posts', AdminPostViewSet, basename='admin-posts')
 router.register(r'store/images', StoreImageViewSet, basename='store-images')
-
+router.register(r'store/boarding-services', BoardingServiceViewSet, basename='boarding-services')
+router.register(r'store/grooming-services', GroomingServiceViewSet, basename='grooming-services')
+router.register(r'store/boarding-pricings', BoardingServicePricingViewset, basename='boarding-pricings')
+router.register(r'store/grooming-pricings', GroomingServicePricingViewset, basename='grooming-pricings')
 
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,11 +7,9 @@ requires-python = ">=3.13"
 dependencies = [
     "django>=5.2.4",
     "django-cors-headers>=4.7.0",
-    "django-environ>=0.12.0",
     "django-filter>=25.1",
-    "django-oauth-toolkit>=3.0.1",
     "djangorestframework>=3.16.0",
     "djangorestframework-simplejwt>=5.5.1",
-    "pillow>=11.3.0",
+    "mysqlclient>=2.2.7",
     "python-dotenv>=1.1.1",
 ]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -18,12 +18,10 @@ source = { virtual = "." }
 dependencies = [
     { name = "django" },
     { name = "django-cors-headers" },
-    { name = "django-environ" },
     { name = "django-filter" },
-    { name = "django-oauth-toolkit" },
     { name = "djangorestframework" },
     { name = "djangorestframework-simplejwt" },
-    { name = "pillow" },
+    { name = "mysqlclient" },
     { name = "python-dotenv" },
 ]
 
@@ -156,15 +154,6 @@ wheels = [
 ]
 
 [[package]]
-name = "django-environ"
-version = "0.12.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/04/65d2521842c42f4716225f20d8443a50804920606aec018188bbee30a6b0/django_environ-0.12.0.tar.gz", hash = "sha256:227dc891453dd5bde769c3449cf4a74b6f2ee8f7ab2361c93a07068f4179041a", size = 56804, upload-time = "2025-01-13T17:03:37.74Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/b3/0a3bec4ecbfee960f39b1842c2f91e4754251e0a6ed443db9fe3f666ba8f/django_environ-0.12.0-py2.py3-none-any.whl", hash = "sha256:92fb346a158abda07ffe6eb23135ce92843af06ecf8753f43adf9d2366dcc0ca", size = 19957, upload-time = "2025-01-13T17:03:32.918Z" },
-]
-
-[[package]]
 name = "django-filter"
 version = "25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -174,21 +163,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b5/40/c702a6fe8cccac9bf426b55724ebdf57d10a132bae80a17691d0cf0b9bac/django_filter-25.1.tar.gz", hash = "sha256:1ec9eef48fa8da1c0ac9b411744b16c3f4c31176c867886e4c48da369c407153", size = 143021, upload-time = "2025-02-14T16:30:53.238Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/a6/70dcd68537c434ba7cb9277d403c5c829caf04f35baf5eb9458be251e382/django_filter-25.1-py3-none-any.whl", hash = "sha256:4fa48677cf5857b9b1347fed23e355ea792464e0fe07244d1fdfb8a806215b80", size = 94114, upload-time = "2025-02-14T16:30:50.435Z" },
-]
-
-[[package]]
-name = "django-oauth-toolkit"
-version = "3.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "django" },
-    { name = "jwcrypto" },
-    { name = "oauthlib" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/d3/d7628a7a4899bf5aafc9c1ec121c507470b37a247f7628acae6e0f78e0d6/django_oauth_toolkit-3.0.1.tar.gz", hash = "sha256:7200e4a9fb229b145a6d808cbf0423b6d69a87f68557437733eec3c0cf71db02", size = 99816, upload-time = "2024-09-07T14:07:57.124Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/40/e556bc19ba65356fe5f0e48ca01c50e81f7c630042fa7411b6ab428ecf68/django_oauth_toolkit-3.0.1-py3-none-any.whl", hash = "sha256:3ef00b062a284f2031b0732b32dc899e3bbf0eac221bbb1cffcb50b8932e55ed", size = 77299, upload-time = "2024-09-07T14:08:43.225Z" },
 ]
 
 [[package]]
@@ -206,6 +180,20 @@ wheels = [
 [[package]]
 name = "djangorestframework-simplejwt"
 version = "5.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "djangorestframework" },
+    { name = "pyjwt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/27/2874a325c11112066139769f7794afae238a07ce6adf96259f08fd37a9d7/djangorestframework_simplejwt-5.5.1.tar.gz", hash = "sha256:e72c5572f51d7803021288e2057afcbd03f17fe11d484096f40a460abc76e87f", size = 101265, upload-time = "2025-07-21T16:52:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/94/fdfb7b2f0b16cd3ed4d4171c55c1c07a2d1e3b106c5978c8ad0c15b4a48b/djangorestframework_simplejwt-5.5.1-py3-none-any.whl", hash = "sha256:2c30f3707053d384e9f315d11c2daccfcb548d4faa453111ca19a542b732e469", size = 107674, upload-time = "2025-07-21T16:52:07.493Z" },
+]
+
+[[package]]
+name = "mysqlclient"
+version = "2.2.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
@@ -310,6 +298,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6", size = 172736, upload-time = "2024-03-30T13:22:22.564Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc", size = 117552, upload-time = "2024-03-30T13:22:20.476Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
後端 API 優化
新增 BoardingServiceViewSet、GroomingServiceViewSet、BoardingServicePricingViewset 與 GroomingServicePricingViewset，使用 Django REST Framework 提供寄宿/美容服務與其價格模型的 CRUD 操作。

在 urls.py 中註冊上述 ViewSet 的 API 路由，實現 RESTful 端點以管理寄宿與美容服務及其價格。

序列化器優化
更新 BoardingServiceSerializer 與 GroomingServiceSerializer，支援巢狀建立相關價格物件，允許在單一請求中同時建立服務與其對應的價格資料。

專案設定
在 .vscode/settings.json 中新增 Python 環境設定，指定預設環境管理器與專案列表以便於 Python 開發。

更新 pyproject.toml 相依套件，移除部分套件並新增 mysqlclient 以支援 MySQL 資料庫。