### PR TITLE
feat: 重構與強化後端客戶與使用者 API 端點

### DIFF
--- a/backend/pet_booking/customers/serializers.py
+++ b/backend/pet_booking/customers/serializers.py
@@ -57,6 +57,8 @@ class PetSerializer(serializers.ModelSerializer):
             'breed',
             'age',
             'weight',
+            'size',
+            'fur_amount',
             'spayed_or_neutered',
             'microchip',
             'last_deworming_date',

--- a/backend/pet_booking/customers/views.py
+++ b/backend/pet_booking/customers/views.py
@@ -1,3 +1,162 @@
-from django.shortcuts import render
+# apps/customers/views.py
+from rest_framework import viewsets, status
+from rest_framework.permissions import BasePermission, AllowAny, IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.decorators import action
+# from rest_framework.exceptions import PermissionDenied
+from rest_framework.pagination import PageNumberPagination
+from django_filters import rest_framework as filters
+from django_filters.rest_framework import DjangoFilterBackend
+from .models import CustomersProfile, LikeStore, Pet
+from .serializers import CustomersProfileSerializer, LikeStoreSerializer, PetSerializer
+from pet_booking.users.models import User, UserRole
+# from pet_booking.users.serializers import UserSerializer
 
 # Create your views here.
+class IsAdminOrOwner(BasePermission):
+    """
+    Admin 可存取全部資料，普通會員只能存取自己的資料
+    """
+    def has_object_permission(self, request, view, obj):
+        # 管理員可以操作所有物件
+        if request.user.is_authenticated and request.user.role == UserRole.ADMIN:
+            return True
+        # 物件必須有 user_id 欄位（ForeignKey 到 User）and # 操作的user id 要等於 發出request的 user id 
+        return hasattr(obj, "user_id") and obj.user_id == request.user
+
+class StandardResultsSetPagination(PageNumberPagination):
+    page_size = 10              # 每頁顯示 10 筆
+    page_size_query_param = 'page_size'  # 可用 URL ?page_size=20 動態調整
+    max_page_size = 50         # 最大每頁顯示數
+    
+class BaseOwnerViewSet(viewsets.ModelViewSet):
+    """
+    Base ViewSet：
+      - Admin 全部可見
+      - 普通使用者只能看到/操作自己的資料
+      - 建立時自動綁定登入用戶
+      - 僅 Admin 可用 user_id 過濾
+    """
+    permission_classes = [IsAuthenticated, IsAdminOrOwner]
+    filter_backends = [DjangoFilterBackend]
+    pagination_class = StandardResultsSetPagination
+
+    def get_queryset(self):
+        user = self.request.user
+        if user.is_authenticated and user.role == UserRole.ADMIN:
+            return self.queryset.all().order_by('-id')
+        return self.queryset.filter(user_id=user).order_by('-id')
+
+    def perform_create(self, serializer):
+        # 強制綁定當前登入使用者
+        serializer.save(user_id=self.request.user)
+
+class CustomersProfileFilter(filters.FilterSet):
+    class Meta:
+        model = CustomersProfile
+        fields = []  # 先不開任何欄位
+
+    @property
+    def filters(self):
+        # 取得原本所有欄位型別
+        filters_dict = super().filters.copy()
+        # 根據 request.user 權限動態調整
+        user = getattr(getattr(self, 'request', None), 'user', None)
+        if user and user.is_authenticated and user.role == UserRole.ADMIN:
+            # 只有 admin 能用 user_id 過濾
+            filters_dict['user_id'] = filters.ModelChoiceFilter(queryset=User.objects.all())
+        return filters_dict
+
+class CustomersProfileViewSet(BaseOwnerViewSet):
+    http_method_names = ['get', 'post', 'patch', 'delete']
+    queryset = CustomersProfile.objects.all()
+    serializer_class = CustomersProfileSerializer
+    filterset_class = CustomersProfileFilter
+
+    @action(detail=False, methods=['get', 'patch', 'delete'], url_path='me')
+    def me(self, request):
+        """
+        GET    /customer/profiles/me/     取得自己的 CustomersProfile
+        PATCH  /customer/profiles/me/     修改自己的 CustomersProfile
+        DELETE /customer/profiles/me/     刪除自己的 CustomersProfile
+        """
+        try:
+            profile = CustomersProfile.objects.get(user_id=request.user)
+        except CustomersProfile.DoesNotExist:
+            return Response({'detail': '沒有找到您的客戶資料'}, status=status.HTTP_404_NOT_FOUND)
+
+        if request.method.lower() == 'get':
+            serializer = self.get_serializer(profile)
+            return Response(serializer.data)
+        elif request.method.lower() == 'patch':
+            serializer = self.get_serializer(profile, data=request.data, partial=True)
+            serializer.is_valid(raise_exception=True)
+            serializer.save()
+            return Response(serializer.data)
+        elif request.method.lower() == 'delete':
+            profile.delete()
+            return Response({"detail": "已刪除"}, status=status.HTTP_204_NO_CONTENT)
+
+class LikeStoreFilter(filters.FilterSet):
+    class Meta:
+        model = LikeStore
+        fields = []  # 先不開任何欄位
+
+    @property
+    def filters(self):
+        # 取得原本所有欄位型別
+        filters_dict = super().filters.copy()
+        # 根據 request.user 權限動態調整
+        user = getattr(getattr(self, 'request', None), 'user', None)
+        if user and user.is_authenticated and user.role == UserRole.ADMIN:
+            # 只有 admin 能用 user_id 過濾
+            filters_dict['user_id'] = filters.ModelChoiceFilter(queryset=User.objects.all())
+        return filters_dict
+
+class LikeStoreViewSet(BaseOwnerViewSet):
+    http_method_names = ['get', 'post', 'patch', 'delete']
+    queryset = LikeStore.objects.all()
+    serializer_class = LikeStoreSerializer
+    filterset_class = LikeStoreFilter
+
+
+    @action(detail=False, methods=['get'], url_path='me')
+    def me(self, request):
+        """
+        GET /customer/likestores/me/ 取得自己的 LikeStore 列表
+        """
+        likestores = LikeStore.objects.filter(user_id=request.user).order_by('-id')
+        serializer = self.get_serializer(likestores, many=True)
+        return Response(serializer.data)
+
+class PetFilter(filters.FilterSet):
+    class Meta:
+        model = Pet
+        fields = []  # 先不開任何欄位
+
+    @property
+    def filters(self):
+        # 取得原本所有欄位型別
+        filters_dict = super().filters.copy()
+        # 根據 request.user 權限動態調整
+        user = getattr(getattr(self, 'request', None), 'user', None)
+        if user and user.is_authenticated and user.role == UserRole.ADMIN:
+            # 只有 admin 能用 user_id 過濾
+            filters_dict['user_id'] = filters.ModelChoiceFilter(queryset=User.objects.all())
+        return filters_dict
+
+class PetViewSet(BaseOwnerViewSet):
+    http_method_names = ['get', 'post', 'patch', 'delete']
+    queryset = Pet.objects.all()
+    serializer_class = PetSerializer
+    filterset_class = PetFilter
+
+
+    @action(detail=False, methods=['get'], url_path='me')
+    def me(self, request):
+        """
+        GET /customer/pets/me/ 取得自己的 Pet 列表
+        """
+        pets = Pet.objects.filter(user_id=request.user).order_by('-id')
+        serializer = self.get_serializer(pets, many=True)
+        return Response(serializer.data)

--- a/backend/pet_booking/settings.py
+++ b/backend/pet_booking/settings.py
@@ -44,7 +44,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     'rest_framework',
-    'corsheaders'
+    'corsheaders',
     'django_filters',
     'rest_framework_simplejwt',
     'rest_framework_simplejwt.token_blacklist',

--- a/backend/pet_booking/urls.py
+++ b/backend/pet_booking/urls.py
@@ -17,18 +17,10 @@ from pet_booking.services.views import *
 from pet_booking.reservations.views import *
 
 router = DefaultRouter(trailing_slash=False)
-
-urlpatterns = [
-    path("admin/", admin.site.urls),
-    path('api/', include(router.urls)),
-    path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
-    path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
-    path('api/token/verify/', TokenVerifyView.as_view(), name='token_verify'),
-    path('api/token/blacklist/', TokenBlacklistView.as_view(), name='token_blacklist'),
-    path('o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
-]
-
-router = DefaultRouter(trailing_slash=False)
+router.register(r'users', UserViewSet, basename='users')
+router.register(r'customer/profiles', CustomersProfileViewSet, basename='customer-profile')
+router.register(r'customer/likestores', LikeStoreViewSet, basename='likestores')
+router.register(r'customer/pets', PetViewSet, basename='pets')
 router.register(r'store/profile', StoreProfileViewSet, basename='store-profile')
 router.register(r'admin/stores', StoreAdminViewSet, basename='admin-stores')
 router.register(r'store/posts', StorePostViewSet, basename='store-posts')
@@ -38,6 +30,16 @@ router.register(r'store/boarding-services', BoardingServiceViewSet, basename='bo
 router.register(r'store/grooming-services', GroomingServiceViewSet, basename='grooming-services')
 router.register(r'store/boarding-pricings', BoardingServicePricingViewset, basename='boarding-pricings')
 router.register(r'store/grooming-pricings', GroomingServicePricingViewset, basename='grooming-pricings')
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    path('api/', include(router.urls)),
+    path('api/token', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('api/token/refresh', TokenRefreshView.as_view(), name='token_refresh'),
+    path('api/token/verify', TokenVerifyView.as_view(), name='token_verify'),
+    path('api/token/blacklist', TokenBlacklistView.as_view(), name='token_blacklist'),
+    path('o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
+]
 
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/backend/pet_booking/users/views.py
+++ b/backend/pet_booking/users/views.py
@@ -1,3 +1,104 @@
-from django.shortcuts import render
-
+# apps/users/views.py
+from rest_framework import viewsets, status
+from rest_framework.permissions import BasePermission, AllowAny, IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.decorators import action
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.pagination import PageNumberPagination
+# from django_filters import rest_framework as filter
+from django_filters.rest_framework import DjangoFilterBackend
+from .models import User, UserRole
+from .serializers import UserSerializer
 # Create your views here.
+
+class IsAdminOrSelf(BasePermission):
+    """
+    只允許 admin 查看/修改/刪除任何人，其他角色只能操作自己。
+    """
+    def has_object_permission(self, request, view, obj):
+        if request.user.is_authenticated and request.user.role == UserRole.ADMIN:
+            return True
+        return obj == request.user
+    
+class IsAdminForList(BasePermission):
+    """
+    限制只有 admin 才能使用 list API（GET /users/）
+    """
+    def has_permission(self, request, view):
+        if view.action == 'list':
+            if not request.user.is_authenticated or request.user.role != UserRole.ADMIN:
+                # 這裡直接丟出自訂 403 訊息
+                raise PermissionDenied(detail="只有系統管理者能查看所有使用者資料")
+        return True
+
+class StandardResultsSetPagination(PageNumberPagination):
+    page_size = 10              # 每頁顯示 10 筆
+    page_size_query_param = 'page_size'  # 可用 URL ?page_size=20 動態調整
+    max_page_size = 50         # 最大每頁顯示數
+
+class UserViewSet(viewsets.ModelViewSet):
+    http_method_names = ['get', 'post', 'patch', 'delete']
+    # queryset =User.objects.all().order_by('-user_id')
+    serializer_class = UserSerializer
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = ['role']  # 可根據需求增加欄位
+    pagination_class = StandardResultsSetPagination
+
+    def get_queryset(self):
+        user = self.request.user
+        if user.is_authenticated and user.role == UserRole.ADMIN:
+            # Admin 看全部
+            return User.objects.all().order_by('-user_id')
+        # 其他角色只能查自己
+        return User.objects.filter(pk=user.pk)
+    
+    def get_permissions(self):
+        if self.action in ['create']:
+            permission_classes = [AllowAny]
+        elif self.action in ['list']:
+            permission_classes = [IsAuthenticated, IsAdminForList]
+        elif self.action in ['me']:  # /users/me/ 只要登入即可
+            permission_classes = [IsAuthenticated]
+        else:
+            permission_classes = [IsAuthenticated, IsAdminOrSelf]
+        return [permission() for permission in permission_classes]
+
+    @action(detail=False, methods=['get', 'patch', 'delete'], url_path='me')
+    def me(self, request):
+        """
+        GET    /users/me/    取得自己資料
+        PATCH  /users/me/    部分更新自己資料（包含密碼）
+        DELETE /users/me/    刪除自己帳號
+        """
+        if request.method.lower() == 'get':
+            serializer = self.get_serializer(request.user)
+            return Response(serializer.data)
+
+        elif request.method.lower() == 'patch':
+            serializer = self.get_serializer(
+                request.user,
+                data=request.data,
+                partial=True
+            )
+            serializer.is_valid(raise_exception=True)
+            serializer.save()  # 會自動呼叫 serializer 的 update，包含密碼加密
+            return Response(serializer.data)
+
+        elif request.method.lower() == 'delete':
+            request.user.delete()
+            return Response(
+                {"detail": "帳號已刪除"},
+                status=status.HTTP_204_NO_CONTENT
+            )
+        
+    def create(self, request, *args, **kwargs):
+        print(request.data)
+        request_data = request.data
+        serializer = self.get_serializer(data=request_data)
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+
+    def perform_create(self, serializer):
+        serializer.save()


### PR DESCRIPTION
API 端點優化：

新增 User、CustomersProfile、LikeStore 與 Pet 的 ViewSet，並實作專屬權限類別以確保管理員與一般使用者的存取控制。

為 User 端點新增 /me API，讓使用者能管理自己的資料。

加入分頁與動態篩選功能（包含僅限管理員使用的篩選條件）。
（backend/pet_booking/customers/views.py、backend/pet_booking/users/views.py）

路由與設定更新：

在 API 路由中註冊上述新 ViewSet，並更新 URL 規則以納入新端點，同時調整 JWT 驗證相關端點的命名與一致性。

在 INSTALLED_APPS 中新增 django_filters，支援 API 的進階篩選功能。
（backend/pet_booking/urls.py、backend/pet_booking/settings.py）

序列化器改進：

擴充 Pet 序列化器，新增 size 與 fur_amount 欄位，以提供更完整的寵物資訊呈現。
（backend/pet_booking/customers/serializers.py）