### PR TITLE
feat: 後端使用者與顧客篩選及註冊統計功能改進

### DIFF
--- a/backend/pet_booking/customers/serializers.py
+++ b/backend/pet_booking/customers/serializers.py
@@ -7,7 +7,8 @@ from pet_booking.stores.serializers import StoreSerializer
 class CustomersProfileSerializer(serializers.ModelSerializer):
     user_id = serializers.SlugRelatedField(
         slug_field='user_id',
-        queryset=User.objects.all()
+        # queryset=User.objects.all(),
+        read_only=True
     )
 
     class Meta:
@@ -25,7 +26,8 @@ class CustomersProfileSerializer(serializers.ModelSerializer):
 class LikeStoreSerializer(serializers.ModelSerializer):
     user_id = serializers.SlugRelatedField(
         slug_field='user_id',
-        queryset=User.objects.all()
+        # queryset=User.objects.all(),
+        read_only=True
     )
     
     store_id = serializers.SlugRelatedField(
@@ -43,7 +45,8 @@ class LikeStoreSerializer(serializers.ModelSerializer):
 class PetSerializer(serializers.ModelSerializer):
     user_id = serializers.SlugRelatedField(
         slug_field='user_id',
-        queryset=User.objects.all()
+        # queryset=User.objects.all(),
+        read_only=True
     )
     
     class Meta:

--- a/backend/pet_booking/customers/views.py
+++ b/backend/pet_booking/customers/views.py
@@ -51,21 +51,43 @@ class BaseOwnerViewSet(viewsets.ModelViewSet):
         # 強制綁定當前登入使用者
         serializer.save(user_id=self.request.user)
 
+# ------------------------filter------------------------------
 class CustomersProfileFilter(filters.FilterSet):
     class Meta:
         model = CustomersProfile
-        fields = []  # 先不開任何欄位
+        fields = []  # 預設沒有過濾欄位
 
-    @property
-    def filters(self):
-        # 取得原本所有欄位型別
-        filters_dict = super().filters.copy()
-        # 根據 request.user 權限動態調整
-        user = getattr(getattr(self, 'request', None), 'user', None)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        user = getattr(self.request, 'user', None)
         if user and user.is_authenticated and user.role == UserRole.ADMIN:
             # 只有 admin 能用 user_id 過濾
-            filters_dict['user_id'] = filters.ModelChoiceFilter(queryset=User.objects.all())
-        return filters_dict
+            self.filters['user_id'] = filters.ModelChoiceFilter(queryset=User.objects.all())
+
+
+class LikeStoreFilter(filters.FilterSet):
+    class Meta:
+        model = LikeStore
+        fields = []  # 預設沒有過濾欄位
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        user = getattr(self.request, 'user', None)
+        if user and user.is_authenticated and user.role == UserRole.ADMIN:
+            self.filters['user_id'] = filters.ModelChoiceFilter(queryset=User.objects.all())
+
+
+class PetFilter(filters.FilterSet):
+    class Meta:
+        model = Pet
+        fields = []  # 預設沒有過濾欄位
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        user = getattr(self.request, 'user', None)
+        if user and user.is_authenticated and user.role == UserRole.ADMIN:
+            self.filters['user_id'] = filters.ModelChoiceFilter(queryset=User.objects.all())
+
 
 class CustomersProfileViewSet(BaseOwnerViewSet):
     http_method_names = ['get', 'post', 'patch', 'delete']
@@ -97,21 +119,7 @@ class CustomersProfileViewSet(BaseOwnerViewSet):
             profile.delete()
             return Response({"detail": "已刪除"}, status=status.HTTP_204_NO_CONTENT)
 
-class LikeStoreFilter(filters.FilterSet):
-    class Meta:
-        model = LikeStore
-        fields = []  # 先不開任何欄位
 
-    @property
-    def filters(self):
-        # 取得原本所有欄位型別
-        filters_dict = super().filters.copy()
-        # 根據 request.user 權限動態調整
-        user = getattr(getattr(self, 'request', None), 'user', None)
-        if user and user.is_authenticated and user.role == UserRole.ADMIN:
-            # 只有 admin 能用 user_id 過濾
-            filters_dict['user_id'] = filters.ModelChoiceFilter(queryset=User.objects.all())
-        return filters_dict
 
 class LikeStoreViewSet(BaseOwnerViewSet):
     http_method_names = ['get', 'post', 'patch', 'delete']
@@ -128,22 +136,6 @@ class LikeStoreViewSet(BaseOwnerViewSet):
         likestores = LikeStore.objects.filter(user_id=request.user).order_by('-id')
         serializer = self.get_serializer(likestores, many=True)
         return Response(serializer.data)
-
-class PetFilter(filters.FilterSet):
-    class Meta:
-        model = Pet
-        fields = []  # 先不開任何欄位
-
-    @property
-    def filters(self):
-        # 取得原本所有欄位型別
-        filters_dict = super().filters.copy()
-        # 根據 request.user 權限動態調整
-        user = getattr(getattr(self, 'request', None), 'user', None)
-        if user and user.is_authenticated and user.role == UserRole.ADMIN:
-            # 只有 admin 能用 user_id 過濾
-            filters_dict['user_id'] = filters.ModelChoiceFilter(queryset=User.objects.all())
-        return filters_dict
 
 class PetViewSet(BaseOwnerViewSet):
     http_method_names = ['get', 'post', 'patch', 'delete']


### PR DESCRIPTION
**序列化器欄位調整**
將 CustomersProfileSerializer、LikeStoreSerializer 與 PetSerializer 中的 user_id 欄位改為唯讀（read-only），取代原本使用 queryset 的設定，確保此欄位不會被外部資料任意修改。

**動態篩選功能改進**
重構 CustomersProfileFilter、LikeStoreFilter 及 PetFilter 類別，改為只對管理員使用者動態加入 user_id 篩選條件，簡化並集中角色基礎篩選邏輯，移除舊有以屬性實作的篩選方式。

**使用者註冊統計 API**
在 UserViewSet 新增 registered_all 端點，提供管理員會員與店家註冊總數及每日註冊數統計，涵蓋所有時間、最近 7 天及最近 30 天，並分別列出各角色每日統計資料。
引入所需模組 (now, TruncDate, Count, timedelta)，以支援日期聚合運算與新統計 API 功能