### PR TITLE
feat: 停用部分後端分頁並優化前端店家審核與管理介面

### DIFF
--- a/backend/pet_booking/stores/views.py
+++ b/backend/pet_booking/stores/views.py
@@ -187,17 +187,17 @@ class StoreImageViewSet(viewsets.ModelViewSet):
 # 管理者
 # 分頁
 
-class StorePagination(PageNumberPagination):
-    page_size = 5
-    page_size_query_param = 'page_size'
-    max_page_size = 50
+# class StorePagination(PageNumberPagination):
+#     page_size = 5
+#     page_size_query_param = 'page_size'
+#     max_page_size = 50
 
 # 管理者店家頁
 class StoreAdminViewSet(viewsets.ModelViewSet):
     queryset = Store.objects.all().order_by('-created_at')
     filter_backends = [DjangoFilterBackend]
     filterset_class= StoreFilter
-    pagination_class = StorePagination
+    # pagination_class = StorePagination
     permission_classes = [IsAuthenticated]
 
     def get_serializer_class(self):
@@ -225,7 +225,7 @@ class AdminPostViewSet(viewsets.ModelViewSet):
     serializer_class = PostSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_class= PostFilter
-    pagination_class = StorePagination
+    # pagination_class = StorePagination
     permission_classes = [IsAuthenticated]
 
 
@@ -252,16 +252,16 @@ class CustomerStoreFilter(django_filters.FilterSet):
         return queryset.filter(address__district=value)
 
 
-class CustomerStorePagination(PageNumberPagination):
-    page_size = 9
-    page_size_query_param = 'page_size'
-    max_page_size = 50
+# class CustomerStorePagination(PageNumberPagination):
+#     page_size = 9
+#     page_size_query_param = 'page_size'
+#     max_page_size = 50
 
 class CustomerStoreViewSet(viewsets.ModelViewSet):
     http_method_names = ['get']
     permission_classes = []
     serializer_class = StoreListSerializer
-    pagination_class = CustomerStorePagination
+    # pagination_class = CustomerStorePagination
     filter_backends = [DjangoFilterBackend]
     filterset_class = CustomerStoreFilter
     queryset = Store.objects.filter(status='confirmed').order_by('-created_at')
@@ -298,16 +298,16 @@ class CustomerPostFilter(django_filters.FilterSet):
         fields = ['type']
     
 
-class CustomerPostPagination(PageNumberPagination):
-    page_size = 10
-    page_size_query_param = 'page_size'
-    max_page_size = 50
+# class CustomerPostPagination(PageNumberPagination):
+#     page_size = 10
+#     page_size_query_param = 'page_size'
+#     max_page_size = 50
 
 class CustomerPostViewSet(viewsets.ModelViewSet):
     permission_classes = []
     http_method_names = ['get']
     serializer_class = PostSerializer
-    pagination_class = CustomerPostPagination
+    # pagination_class = CustomerPostPagination
     filter_backends = [DjangoFilterBackend]
     filterset_class = CustomerPostFilter
     queryset = Post.objects.filter(status='confirmed').order_by('-created_at')

--- a/frontend/src/pages/Admin/Stores/StoreManagement.vue
+++ b/frontend/src/pages/Admin/Stores/StoreManagement.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed,onMounted} from "vue";
+import { ref, computed, onMounted } from "vue";
 import Table from "../../../components/UI/Table.vue";
 import StoreCard from "./StoreCard.vue";
 import Pagination from "../../../components/common/Pagination.vue";
@@ -11,7 +11,7 @@ const storeData = async () => {
   try {
     const res = await api.get("admin/stores");
     console.log(res.data); // 調試 API 響應
-    stores.value = Array.isArray(res.data) ? res.data : []; 
+    stores.value = Array.isArray(res.data) ? res.data : []; // 確保返回值為陣列
   } catch (err) {
     alert("無法取得店家資料");
     stores.value = []; // 確保失敗時為空陣列
@@ -26,15 +26,14 @@ onMounted(() => {
 const statusOptions = [
   { label: "首次申請", value: "pending" },
   { label: "補件申請", value: "repending" },
-  { label: "退回補件", value: "rechecked" }
+  { label: "退回補件", value: "rechecked" },
 ];
 
 // 狀態文字動態顯示
 const statusLabel = computed(() => {
-  const found = statusOptions.find(opt => opt.value === selectedStatus.value);
+  const found = statusOptions.find((opt) => opt.value === selectedStatus.value);
   return found ? found.label : "";
 });
-
 
 const pageSize = 5;
 // 第一個表格的分頁邏輯（審核中的店家）
@@ -47,7 +46,9 @@ const selectedStatus = ref("pending");
 
 // 根據狀態篩選店家
 const pendingStores = computed(() => {
-  return stores.value.filter((store) => store.status?.trim() === selectedStatus.value);
+  return stores.value.filter(
+    (store) => store.status?.trim() === selectedStatus.value
+  );
 });
 
 const operatingStores = computed(() => {

--- a/frontend/src/pages/Admin/Stores/StoreReview.vue
+++ b/frontend/src/pages/Admin/Stores/StoreReview.vue
@@ -87,14 +87,32 @@ function closeModal() {
   showModal.value = false;
   rejectReason.value = "";
 }
-function confirmReject() {
-  // 這裡可以串 API
-  alert("退件原因：" + rejectReason.value);
-  closeModal();
-}
-function approve() {
-  alert("核准完成！");
-}
+const confirmReject = async () => {
+  try {
+    const res = await api.patch(`/admin/stores/${storeId.value}`, {
+      status: "rechecked",
+      reject_content: rejectReason.value,
+    });
+    alert("退件原因已更新：" + rejectReason.value);
+    closeModal();
+  } catch (error) {
+    console.error("更新失敗", error);
+    alert("更新失敗，請稍後再試");
+  }
+  router.push("/admin/stores/manage");
+};
+const approve = async () => {
+  try {
+    const res = await api.patch(`/admin/stores/${storeId.value}`, {
+      status: "confirmed",
+    });
+    alert("核准完成！");
+  } catch (error) {
+    console.error("核准失敗", error);
+    alert("核准失敗，請稍後再試");
+  }
+  router.push("/admin/stores/manage");
+};
 function setService(svc) {
   router.replace({ query: { ...route.query, service: svc } });
 }
@@ -123,18 +141,23 @@ function back() {
       <!-- 基本資訊 -->
       <section>
         <div class="sr-row">
-          <span class="sr-label">店家名稱</span><span class="sr-value">{{ currentStore.store_name }}</span>
+          <span class="sr-label">店家名稱</span
+          ><span class="sr-value">{{ currentStore.store_name }}</span>
         </div>
         <div class="sr-row">
-          <span class="sr-label">負責人姓名</span><span class="sr-value">{{ currentStore.owner_name }}</span>
+          <span class="sr-label">負責人姓名</span
+          ><span class="sr-value">{{ currentStore.owner_name }}</span>
         </div>
         <div class="sr-row">
-          <span class="sr-label">店家地址</span><span class="sr-value">{{ currentStore.address.county }}{{
-            currentStore.address.district
-          }}{{ currentStore.address.detail }}</span>
+          <span class="sr-label">店家地址</span
+          ><span class="sr-value"
+            >{{ currentStore.address.county }}{{ currentStore.address.district
+            }}{{ currentStore.address.detail }}</span
+          >
         </div>
         <div class="sr-row">
-          <span class="sr-label">聯絡電話</span><span class="sr-value">{{ currentStore.phone }}</span>
+          <span class="sr-label">聯絡電話</span
+          ><span class="sr-value">{{ currentStore.phone }}</span>
         </div>
         <div class="sr-row">
           <span class="sr-label">信箱</span>
@@ -142,22 +165,26 @@ function back() {
         </div>
 
         <div class="sr-row">
-          <span class="sr-label">提供接送服務</span><span class="sr-value">{{
+          <span class="sr-label">提供接送服務</span
+          ><span class="sr-value">{{
             bullet(currentStore.pick_up_service)
           }}</span>
         </div>
         <div class="sr-row">
-          <span class="sr-label">提供美容服務</span><span class="sr-value">{{
+          <span class="sr-label">提供美容服務</span
+          ><span class="sr-value">{{
             bullet(currentStore.grooming_service)
           }}</span>
         </div>
         <div class="sr-row">
-          <span class="sr-label">提供住宿服務</span><span class="sr-value">{{
+          <span class="sr-label">提供住宿服務</span
+          ><span class="sr-value">{{
             bullet(currentStore.boarding_service)
           }}</span>
         </div>
         <div class="sr-row">
-          <span class="sr-label">同一時段允許單筆或多筆預約</span><span class="sr-value">{{
+          <span class="sr-label">同一時段允許單筆或多筆預約</span
+          ><span class="sr-value">{{
             bullet(currentStore.grooming_single_appointment)
           }}</span>
         </div>
@@ -172,10 +199,21 @@ function back() {
         <div v-for="(image, idx) in imageList" :key="idx" class="sr-image-item">
           <p class="sr-image-title">{{ image.title }}</p>
           <div class="sr-image-box">
-            <img v-if="image.url" :src="image.url" :alt="image.title" class="sr-image-img" />
+            <img
+              v-if="image.url"
+              :src="image.url"
+              :alt="image.title"
+              class="sr-image-img"
+            />
             <!-- 佔位用 -->
           </div>
         </div>
+      </div>
+
+      <!-- 退件原因 -->
+      <div v-if="currentStore.status === 'rechecked'" class="sr-reject-content">
+        <h3 class="sr-reject-title">退件原因</h3>
+        <p class="sr-reject-text">{{ currentStore.reject_content }}</p>
       </div>
 
       <!-- 底部按鈕 -->
@@ -193,7 +231,9 @@ function back() {
           </div>
           <div class="sr-modal-row">
             <div class="sr-modal-label">店家編號</div>
-            <div class="sr-modal-label">{{ currentStore.store_id || '0000' }}</div>
+            <div class="sr-modal-label">
+              {{ currentStore.store_id || "0000" }}
+            </div>
           </div>
           <div class="sr-modal-row">
             <div class="sr-modal-label">店家名稱</div>
@@ -204,9 +244,16 @@ function back() {
             <div class="sr-modal-label">{{ currentStore.owner_name }}</div>
           </div>
           <div class="sr-modal-title">退件原因</div>
-          <textarea v-model="rejectReason" placeholder="請輸入退件原因" rows="4" class="sr-modal-textarea"></textarea>
+          <textarea
+            v-model="rejectReason"
+            placeholder="請輸入退件原因"
+            rows="4"
+            class="sr-modal-textarea"
+          ></textarea>
           <div class="sr-modal-btns">
-            <button @click="closeModal" class="sr-modal-btn-outline">返回</button>
+            <button @click="closeModal" class="sr-modal-btn-outline">
+              返回
+            </button>
             <button @click="confirmReject" class="sr-modal-btn">確定</button>
           </div>
         </div>


### PR DESCRIPTION
後端：分頁停用
停用 StorePagination、CustomerStorePagination、CustomerPostPagination 等自訂分頁類別，並註解掉在管理端與客戶端店家/貼文 ViewSet 中的 pagination_class 設定，影響 API 回傳的分頁行為。

前端：店家審核與管理優化
重構管理端店家審核流程，改用非同步 API 呼叫以核准或拒絕店家，確保狀態與拒絕原因能正確傳送後端，並加入錯誤處理。
審核彈窗新增「退回原因」顯示區塊，當店家狀態為 rechecked 時會顯示對應原因。
優化店家管理與審核頁面程式碼可讀性，包括明確的陣列檢查、統一箭頭函式格式，以及更精準的依狀態篩選店家列表邏輯。
改善退回原因的輸入框與彈窗格式，使介面更易讀與友善使用。