### PR TITLE
feat: 使用 django-rest-passwordreset 套件以實現密碼重設功能，並更新設定與網址路由

### DIFF
--- a/backend/pet_booking/settings.py
+++ b/backend/pet_booking/settings.py
@@ -62,12 +62,14 @@ INSTALLED_APPS = [
     'django_filters',
     'rest_framework_simplejwt',
     'rest_framework_simplejwt.token_blacklist',
+    'django_rest_passwordreset',
     'oauth2_provider',
     'pet_booking.customers',
     'pet_booking.reservations',
     'pet_booking.services',
     'pet_booking.stores',
-    'pet_booking.users'
+    # 'pet_booking.users',
+    'pet_booking.users.apps.UsersConfig',
 ]
 
 MIDDLEWARE = [

--- a/backend/pet_booking/urls.py
+++ b/backend/pet_booking/urls.py
@@ -59,6 +59,7 @@ urlpatterns = [
     path('api/register_confirm_code', RegisterConfirmCodeAPIView.as_view(), name='register_confirm_code'),
     path('api/store/register_send_code', StoreRegisterSendCodeAPIView.as_view()),
     path('api/store/register_confirm_code', StoreRegisterConfirmCodeAPIView.as_view()),
+    path('api/password_reset/', include('django_rest_passwordreset.urls', namespace='password_reset')),
 ]
 
 if settings.DEBUG:

--- a/backend/pet_booking/users/apps.py
+++ b/backend/pet_booking/users/apps.py
@@ -1,6 +1,11 @@
+# users/apps.py
 from django.apps import AppConfig
 
 
 class UsersConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "pet_booking.users"
+
+    def ready(self):
+        import pet_booking.users.signals
+

--- a/backend/pet_booking/users/signals.py
+++ b/backend/pet_booking/users/signals.py
@@ -1,0 +1,12 @@
+from django_rest_passwordreset.signals import reset_password_token_created
+from django.dispatch import receiver
+from django.core.mail import send_mail
+
+@receiver(reset_password_token_created)
+def password_reset_token_created(sender, instance, reset_password_token, *args, **kwargs):
+    send_mail(
+        "密碼重設",
+        f"你的密碼重設驗證碼：{reset_password_token.key}",
+        None,
+        [reset_password_token.user.email]
+    )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "django-environ>=0.12.0",
     "django-filter>=25.1",
     "django-oauth-toolkit>=3.0.0",
+    "django-rest-passwordreset>=1.5.0",
     "djangorestframework>=3.16.0",
     "djangorestframework-simplejwt>=5.5.1",
     "pillow>=11.3.0",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -21,6 +21,7 @@ dependencies = [
     { name = "django-environ" },
     { name = "django-filter" },
     { name = "django-oauth-toolkit" },
+    { name = "django-rest-passwordreset" },
     { name = "djangorestframework" },
     { name = "djangorestframework-simplejwt" },
     { name = "pillow" },
@@ -34,6 +35,7 @@ requires-dist = [
     { name = "django-environ", specifier = ">=0.12.0" },
     { name = "django-filter", specifier = ">=25.1" },
     { name = "django-oauth-toolkit", specifier = ">=3.0.0" },
+    { name = "django-rest-passwordreset", specifier = ">=1.5.0" },
     { name = "djangorestframework", specifier = ">=3.16.0" },
     { name = "djangorestframework-simplejwt", specifier = ">=5.5.1" },
     { name = "pillow", specifier = ">=11.3.0" },
@@ -198,6 +200,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fa/d3/d7628a7a4899bf5aafc9c1ec121c507470b37a247f7628acae6e0f78e0d6/django_oauth_toolkit-3.0.1.tar.gz", hash = "sha256:7200e4a9fb229b145a6d808cbf0423b6d69a87f68557437733eec3c0cf71db02", size = 99816, upload-time = "2024-09-07T14:07:57.124Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/40/e556bc19ba65356fe5f0e48ca01c50e81f7c630042fa7411b6ab428ecf68/django_oauth_toolkit-3.0.1-py3-none-any.whl", hash = "sha256:3ef00b062a284f2031b0732b32dc899e3bbf0eac221bbb1cffcb50b8932e55ed", size = 77299, upload-time = "2024-09-07T14:08:43.225Z" },
+]
+
+[[package]]
+name = "django-rest-passwordreset"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/b0/a7c04477b473959a353c5ecd27cd022501be7a764fd88076e2477f64618c/django-rest-passwordreset-1.5.0.tar.gz", hash = "sha256:6da38dd00e0cdb1ed5c403e66beeb90f10f8a1a73ebc13fdd27f2b5d67d14181", size = 209031, upload-time = "2024-11-05T13:55:52.451Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/d1/0e7b96115f1263f33b1558edc9a7cae3f0f7e920b56997078f438f7e1d44/django_rest_passwordreset-1.5.0-py3-none-any.whl", hash = "sha256:862fce99b12198aa1473299aac68febe4f40760a39beabc47f941cff5c9e7280", size = 31265, upload-time = "2024-11-05T13:55:50.893Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
密碼重置功能整合
新增 django-rest-passwordreset 至專案依賴與 INSTALLED_APPS。
在 urls.py 新增 /api/password_reset/ API 路由，支援密碼重置流程。

users app 重構與信號處理
改用 UsersConfig 註冊 users app，以便在 ready() 方法中載入信號。
新增 users/signals.py，於密碼重置請求時發送含重置 token 的電子郵件。