### PR TITLE
feat: 優化店家管理後端與前端，提升圖片上傳限制與店家資訊頁體驗

### DIFF
--- a/backend/pet_booking/stores/serializers.py
+++ b/backend/pet_booking/stores/serializers.py
@@ -23,8 +23,8 @@ class StoreImageSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs):
         store = attrs.get('store')
-        if store and store.images.count() >= 8:
-            raise serializers.ValidationError("最多只能上傳8張圖片")
+        if store and store.images.count() >= 9:
+            raise serializers.ValidationError("最多只能上傳9張圖片")
         return attrs
 
 # 店家詳細頁

--- a/frontend/src/pages/Stores/Info/EditInfo.vue
+++ b/frontend/src/pages/Stores/Info/EditInfo.vue
@@ -1,62 +1,71 @@
 <script setup>
-import { ref } from 'vue'
-import { useRouter } from 'vue-router'
-const router = useRouter()
+import { ref, onMounted } from "vue";
+import { useRouter } from "vue-router";
+const router = useRouter();
+import api from "../../../api/api.js";
+
+const userId = ref(null);
+
+onMounted(async () => {
+  try {
+    const response = await api.get("/users/me");
+    userId.value = response.data.id;
+  } catch (error) {
+    console.error("Error fetching user data:", error);
+  }
+});
 
 const form = ref({
-  name: '',
-  city: '',
-  district: '',
-  detailAddress: '',
-  phone: '',
-  hours: '',
-  services: '',
-  traffic: '',
-  description: '',
-  fb: '',
-  line: '',
-  google:''
-})
-const pickup = ref(true) //接送服務
-const grooming = ref(true) //美容服務
-const boarding = ref(false) //住宿服務
-const boardingTypes = ref([]) // 住宿類型
-const imageNote = ref('') // 圖片說明
+  name: "",
+  address: { county: "", district: "", detail: "" },
+  phone: "",
+  hours: "",
+  services: "",
+  traffic_info: "",
+  description: "",
+  facebook_link: "",
+  line_link: "",
+  google_map_link: "",
+});
+const pick_up_service = ref(true); //接送服務
+const grooming_service = ref(true); //美容服務
+const boarding_service = ref(false); //住宿服務
+const boarding_pet_type = ref([]); // 住宿類型
+const imageNote = ref(""); // 圖片說明
+const imagesToUpload = ref([]); // 用於存儲待上傳的圖片文件
 
 const submitForm = () => {
   console.log({
-    pickup: pickup.value,
-    grooming: grooming.value,
-    boarding: boarding.value,
-    boardingTypes: boardingTypes.value,
-    imageNote: imageNote.value
-  })
-}
+    pick_up_service: pick_up_service.value,
+    grooming_service: grooming_service.value,
+    boarding_service: boarding_service.value,
+    boarding_pet_type: boarding_pet_type.value,
+    imageNote: imageNote.value,
+  });
+};
 //圖片管理區
-const fileInput = ref(null) //綁定 HTML <input type="file"> 的 DOM可以用 fileInput.value.click() 來程式化開啟檔案選擇視窗
-// 先放幾張示意圖；實務上可從後端讀取
-const images = ref([
-  'https://images.unsplash.com/photo-1518791841217-8f162f1e1131?q=80&w=600',
-  'https://images.unsplash.com/photo-1543466835-00a7907e9de1?q=80&w=400',
-  'https://images.unsplash.com/photo-1548199973-03cce0bbc87b?q=80&w=400'
-])
+const fileInput = ref(null); //綁定 HTML <input type="file"> 的 DOM可以用 fileInput.value.click() 來程式化開啟檔案選擇視窗
+// 圖片區
+const images = ref([]);
 const handleFiles = (e) => {
-  const files = Array.from(e.target.files || []) //e.target.files檔案選擇視窗中選的檔案列表（FileList）
-  if (!files.length) return
-  const remain = 9 - images.value.length //圖片上限是 9 張，計算能放幾張
-  const toAdd = files.slice(0, remain) //選了很多張，只取可用的數量
+  const files = Array.from(e.target.files || []);
+  if (!files.length) return;
 
-  // 轉成本地 URL 預覽；實務上改成上傳後拿回 URL
-  toAdd.forEach(f => {
-    const url = URL.createObjectURL(f)
-    images.value.push(url) //即時渲染
-  })
-  e.target.value = '' // 允許重選同一批
-}
+  const remain = 9 - images.value.length; // 限制圖片數量
+  const toAdd = files.slice(0, remain);
+
+  toAdd.forEach((file) => {
+    const url = URL.createObjectURL(file);
+    images.value.push(url); // 即時渲染
+    imagesToUpload.value.push(file); // 存入待上傳的圖片文件
+  });
+
+  e.target.value = ""; // 清空檔案選擇器
+};
 // 刪除圖片
 const remove = (index) => {
-  images.value.splice(index, 1)
-}
+  images.value.splice(index, 1);
+};
 
 //營業時間
 /* 時間下拉：每 30 分一格（可改） */
@@ -65,329 +74,472 @@ const remove = (index) => {
 // Math.floor() → 去掉小數
 // String(...).padStart(2, '0') → 小時補 0，讓 9 變成 09
 const timeOptions = Array.from({ length: 48 }, (_, i) => {
-  const h = String(Math.floor(i / 2)).padStart(2, '0')
-  const m = i % 2 ? '30' : '00'
-  return `${h} : ${m}`
-})
+  const h = String(Math.floor(i / 2)).padStart(2, "0");
+  const m = i % 2 ? "30" : "00";
+  return `${h} : ${m}`;
+});
 
-const openTime = ref('09 : 00')
-const closeTime = ref('17 : 00')
+const daily_opening_time = ref("09 : 00");
+const daily_closing_hours = ref("17 : 00");
 
 /* 公休 */
 const weekdays = [
-  { value: 1, label: '星期一' },
-  { value: 2, label: '星期二' },
-  { value: 3, label: '星期三' },
-  { value: 4, label: '星期四' },
-  { value: 5, label: '星期五' },
-  { value: 6, label: '星期六' },
-  { value: 7, label: '星期日' }
-]
-const offDays = ref([]) // 例： [1,3,7]
+  { value: "星期一", label: "星期一" },
+  { value: "星期二", label: "星期二" },
+  { value: "星期三", label: "星期三" },
+  { value: "星期四", label: "星期四" },
+  { value: "星期五", label: "星期五" },
+  { value: "星期六", label: "星期六" },
+  { value: "星期日", label: "星期日" },
+];
+const close_day = ref([]); // 例： [1,3,7]
 
 /* 服務項目（標籤）固定清單，用來顯示建議按鈕 */
 const serviceOptions = [
-  '寵物美容', '美容剪毛', 'SPA護理', '寵物洗澡', '貓咪專區', '造型美容'
-]
-// 已選中的服務項目（初始值先選 3 個）
-const selectedServices = ref(['寵物美容', '美容剪毛', 'SPA護理'])
+  "寵物美容",
+  "美容剪毛",
+  "SPA護理",
+  "寵物洗澡",
+  "貓咪專區",
+  "造型美容",
+];
+
+const selectedServices = ref([]);
 // 輸入框的文字（用於自訂新增服務項目）
-const tagInput = ref('')
+const tagInput = ref("");
 
 const addService = (name) => {
-  if (!name) return //名稱是空的，就直接跳出（不新增）
-  if (selectedServices.value.length >= 20) return //  如果已達 20 個上限，就不新增
-  if (!selectedServices.value.includes(name)) {  // 如果目前還沒有這個項目
-    selectedServices.value.push(name)  // 加到已選清單中
+  if (!name) return; //名稱是空的，就直接跳出（不新增）
+  if (selectedServices.value.length >= 20) return; //  如果已達 20 個上限，就不新增
+  if (!selectedServices.value.includes(name)) {
+    // 如果目前還沒有這個項目
+    selectedServices.value.push(name); // 加到已選清單中
   }
-}
+};
 
 const addFromInput = () => {
-  const val = tagInput.value.trim() // 去掉輸入前後的空白
-  if (!val) return // 如果輸入是空的，就不新增
-  addService(val) // 新增到已選清單selectedServices
-  tagInput.value = ''  // 新增後清空輸入框
-}
+  const val = tagInput.value.trim(); // 去掉輸入前後的空白
+  if (!val) return; // 如果輸入是空的，就不新增
+  addService(val); // 新增到已選清單selectedServices
+  tagInput.value = ""; // 新增後清空輸入框
+};
 // 移除指定索引的服務項目
-const removeService = (idx) => selectedServices.value.splice(idx, 1)
+const removeService = (idx) => selectedServices.value.splice(idx, 1);
+
+const formatTime = (time) => {
+  return time.replace(/\s/g, ""); // 移除空格，確保格式為 hh:mm
+};
+
+//確認修改送出
+const updateStoreInfo = async () => {
+  // 表單驗證
+  if (
+    !form.value.name ||
+    !form.value.phone ||
+    !form.value.address.county ||
+    !form.value.address.district ||
+    !form.value.address.detail
+  ) {
+    alert("請填寫完整的店家資訊！");
+    return;
+  }
+
+  const uploadedImages = [];
+  for (const file of imagesToUpload.value) {
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+
+      const response = await api.patch(
+        `/store/profile/${userId.value}`,
+        formData
+      );
+      uploadedImages.push(response.data.url); // 獲取後端返回的圖片 URL
+    } catch (error) {
+      console.error("圖片上傳失敗：", error);
+      alert("圖片上傳失敗，請稍後再試！");
+      return;
+    }
+  }
+
+  const payload = {
+    ...form.value,
+    pick_up_service: pick_up_service.value,
+    grooming_service: grooming_service.value,
+    boarding_service: boarding_service.value,
+    boarding_pet_type: boarding_pet_type.value.length
+      ? boarding_pet_type.value
+      : null,
+    images: uploadedImages,
+    daily_opening_time: formatTime(daily_opening_time.value),
+    daily_closing_hours: formatTime(daily_closing_hours.value),
+    close_day: close_day.value,
+    selectedServices: selectedServices.value,
+  };
+
+  console.log("提交的店家資訊：", payload);
+
+  try {
+    const response = await api.patch(`/store/profile/${userId.value}`, payload);
+    console.log("店家資訊更新成功：", response.data);
+    router.push("/stores/info/manage");
+  } catch (error) {
+    console.error("店家資訊更新失敗：", error);
+    alert("更新失敗，請稍後再試！");
+  }
+};
 </script>
+
 <template>
   <div class="w-full px-4 md:px-8 lg:px-16 py-6 max-w-screen-xl mx-auto">
- <!-- ✅ 標題在外面 -->
+    <!-- 標題在外面 -->
     <h1 class="page-title">修改本店資訊</h1>
-   <!-- ✅ 表單卡片（框線在這裡） -->
+    <!-- 表單卡片（框線在這裡） -->
     <section class="form-card">
       <form @submit.prevent="submitForm" class="space-y-6">
-    <!-- 店家照片 -->
-      <section class="photos-section">
-        <div class="photos-header">
-          <label class="photos-title block font-semibold mb-1">店家照片</label>
-          <!-- 上傳按鈕（隱藏 input） -->
-          <input
-            ref="fileInput"
-            type="file"
-            accept="image/*"
-            multiple
-            class="hidden"
-            @change="handleFiles"
-          />
-          <button type="button" class="upload-btn"  @click="fileInput.click()">
-            新增圖片
-          </button>
-        </div>
-
-        
-
-        <!-- 圖片格子 -->
-        <ul class="photo-grid">
-          <!-- 封面（第一張） -->
-          <li v-if="images.length" class="photo-card cover-card">
-            <img :src="images[0]" alt="封面" class="photo-img" />
-            <span class="cover-badge">封面</span>
-            <span class="cover-tip">此張將作為店家頁面的封面圖</span>
-            <button type="button" class="photo-delete" @click="remove(0)">×</button>
-          </li>
-
-          <!-- 其餘縮圖 -->
-          <li
-            v-for="(src, idx) in images.slice(1)"
-            :key="src + idx"
-            class="photo-card"
-          >
-            <img :src="src" class="photo-img" />
-            <button
-              type="button"
-              class="photo-delete"
-              @click="remove(idx + 1)"
-              aria-label="刪除圖片"
+        <!-- 店家照片 -->
+        <section class="photos-section">
+          <div class="photos-header">
+            <label class="photos-title block font-semibold mb-1"
+              >店家照片</label
             >
-              ×
+            <!-- 上傳按鈕（隱藏 input） -->
+            <input
+              ref="fileInput"
+              type="file"
+              accept="image/*"
+              multiple
+              class="hidden"
+              @change="handleFiles"
+            />
+            <button type="button" class="upload-btn" @click="fileInput.click()">
+              新增圖片
             </button>
-          </li>
+          </div>
 
-          <!-- 佔位上傳卡（未達上限時顯示） -->
-          <li
-            v-if="images.length < 9"
-            class="photo-card placeholder-card"
-            @click="fileInput.click()"
-          >
-            <span class="placeholder-plus">＋</span>
-            <span class="placeholder-text">新增圖片</span>
-          </li>
-        </ul>
-      </section>
-        
+          <!-- 圖片格子 -->
+          <ul class="photo-grid">
+            <!-- 封面（第一張） -->
+            <li v-if="images.length" class="photo-card cover-card">
+              <img :src="images[0]" alt="封面" class="photo-img" />
+              <span class="cover-badge">封面</span>
+              <span class="cover-tip">此張將作為店家頁面的封面圖</span>
+              <button type="button" class="photo-delete" @click="remove(0)">
+                ×
+              </button>
+            </li>
+
+            <!-- 其餘縮圖 -->
+            <li
+              v-for="(src, idx) in images.slice(1)"
+              :key="src + idx"
+              class="photo-card"
+            >
+              <img :src="src" class="photo-img" />
+              <button
+                type="button"
+                class="photo-delete"
+                @click="remove(idx + 1)"
+                aria-label="刪除圖片"
+              >
+                ×
+              </button>
+            </li>
+
+            <!-- 佔位上傳卡（未達上限時顯示） -->
+            <li
+              v-if="images.length < 9"
+              class="photo-card placeholder-card"
+              @click="fileInput.click()"
+            >
+              <span class="placeholder-plus">＋</span>
+              <span class="placeholder-text">新增圖片</span>
+            </li>
+          </ul>
+        </section>
 
         <!-- 店家名稱 -->
         <div>
           <label class="block font-semibold mb-1">店家名稱</label>
-          <input type="text" v-model="form.name" placeholder="請輸入店家名稱" class="form-input w-full" />
+          <input type="text" v-model="form.name" class="form-input w-full" />
         </div>
 
         <!-- 地址 -->
         <div>
           <label class="block font-semibold mb-1">地址</label>
           <div class="flex gap-2">
-            <select v-model="form.city" class="form-select w-1/4">
-              <option disabled selected>市</option>
-            </select>
-            <select v-model="form.district" class="form-select w-1/4">
-              <option disabled selected>區</option>
-            </select>
-            <input type="text" v-model="form.detailAddress" class="form-input flex-1" placeholder="請輸入詳細地址" />
+            <input
+              v-model="form.address.county"
+              class="form-select w-1/4"
+              placeholder="請輸入縣市"
+            />
+            <input
+              v-model="form.address.district"
+              class="form-select w-1/4"
+              placeholder="請輸入區域"
+            />
+            <input
+              type="text"
+              v-model="form.address.detail"
+              class="form-input flex-1"
+              placeholder="請輸入詳細地址"
+            />
           </div>
         </div>
 
         <!-- 電話 -->
         <div>
           <label class="block font-semibold mb-1">電話</label>
-          <input type="text" v-model="form.phone" placeholder="請輸入店家電話" class="form-input w-full" />
+          <input type="text" v-model="form.phone" class="form-input w-full" />
         </div>
 
-    <!-- 營業時間 -->
-      <section class="space-y-4">
-        <div class="form-row">
-          <label class="field-label">營業時間</label>
-          <div class="time-row">
-            <span class="time-label">開始營業時間：</span>
-            <select v-model="openTime" class="time-select">
-              <option v-for="t in timeOptions" :key="'open-'+t" :value="t">{{ t }}</option>
-            </select>
+        <!-- 營業時間 -->
+        <section class="space-y-4">
+          <div class="form-row">
+            <label class="field-label">營業時間</label>
+            <div class="time-row">
+              <span class="time-label">開始營業時間：</span>
+              <select v-model="daily_opening_time" class="time-select">
+                <option v-for="t in timeOptions" :key="'open-' + t" :value="t">
+                  {{ t }}
+                </option>
+              </select>
 
-            <span class="mx-2">~</span>
+              <span class="mx-2">~</span>
 
-            <span class="time-label">結束營業時間：</span>
-            <select v-model="closeTime" class="time-select">
-              <option v-for="t in timeOptions" :key="'close-'+t" :value="t">{{ t }}</option>
-            </select>
+              <span class="time-label">結束營業時間：</span>
+              <select v-model="daily_closing_hours" class="time-select">
+                <option v-for="t in timeOptions" :key="'close-' + t" :value="t">
+                  {{ t }}
+                </option>
+              </select>
+            </div>
           </div>
+
+          <!-- 公休時間 -->
+          <div class="form-row">
+            <label class="field-label">公休時間</label>
+            <div class="days-row">
+              <label v-for="d in weekdays" :key="d.value" class="day-item">
+                <input
+                  type="checkbox"
+                  class="day-checkbox"
+                  :value="d.value"
+                  v-model="close_day"
+                />
+                <span>{{ d.label }}</span>
+              </label>
+            </div>
+          </div>
+
+          <!-- 服務項目 -->
+          <div class="form-row">
+            <label class="field-label">服務項目</label>
+
+            <!-- 已選標籤 + 輸入框 -->
+            <div class="service-wrap">
+              <div class="service-input">
+                <!-- 已選標籤 -->
+                <span
+                  v-for="(tag, i) in selectedServices"
+                  :key="tag + i"
+                  class="tag-chip"
+                >
+                  {{ tag }}
+                  <button type="button" class="tag-x" @click="removeService(i)">
+                    ×
+                  </button>
+                </span>
+
+                <!-- 文字輸入（Enter 新增） -->
+                <input
+                  v-model.trim="tagInput"
+                  class="tag-text"
+                  type="text"
+                  placeholder="輸入服務並按 Enter"
+                  @keydown.enter.prevent="addFromInput"
+                />
+              </div>
+            </div>
+
+            <!-- 建議清單（點一下加入） -->
+            <div class="service-suggest">
+              <button
+                v-for="s in serviceOptions"
+                :key="s"
+                type="button"
+                class="suggest-chip"
+                @click="addService(s)"
+                :disabled="selectedServices.includes(s)"
+              >
+                {{ s }}
+              </button>
+            </div>
+          </div>
+        </section>
+
+        <!-- 交通 -->
+        <div>
+          <label class="block font-semibold mb-1">交通</label>
+          <input
+            type="text"
+            v-model="form.traffic_info"
+            class="form-input w-full"
+          />
         </div>
 
-        <!-- 公休時間 -->
-        <div class="form-row">
-          <label class="field-label">公休時間</label>
-          <div class="days-row">
-            <label v-for="d in weekdays" :key="d.value" class="day-item">
-              <input
-                type="checkbox"
-                class="day-checkbox"
-                :value="d.value"
-                v-model="offDays"
-              />
-              <span>{{ d.label }}</span>
+        <!-- 接送、美容、住宿服務（你已完成） -->
+        <!-- 基本服務開關 -->
+
+        <!-- 接送服務 -->
+        <fieldset class="space-y-2">
+          <legend class="font-semibold">接送服務</legend>
+          <label class="inline_link-flex items-center mr-4">
+            <input
+              type="radio"
+              v-model="pick_up_service"
+              :value="true"
+              class="form-radio"
+            />
+            <span class="ml-2">是</span>
+          </label>
+          <label class="inline_link-flex items-center">
+            <input
+              type="radio"
+              v-model="pick_up_service"
+              :value="false"
+              class="form-radio"
+            />
+            <span class="ml-2">否</span>
+          </label>
+        </fieldset>
+
+        <!-- 美容服務 -->
+        <fieldset class="space-y-2">
+          <legend class="font-semibold">美容服務</legend>
+          <label class="inline_link-flex items-center mr-4">
+            <input
+              type="radio"
+              v-model="grooming_service"
+              :value="true"
+              class="form-radio"
+            />
+            <span class="ml-2">是</span>
+          </label>
+          <label class="inline_link-flex items-center">
+            <input
+              type="radio"
+              v-model="grooming_service"
+              :value="false"
+              class="form-radio"
+            />
+            <span class="ml-2">否</span>
+          </label>
+        </fieldset>
+
+        <!-- 住宿服務 -->
+        <fieldset class="space-y-2">
+          <legend class="font-semibold">住宿服務</legend>
+          <label class="inline_link-flex items-center mr-4">
+            <input
+              type="radio"
+              v-model="boarding_service"
+              :value="true"
+              class="form-radio"
+            />
+            <span class="ml-2">是</span>
+          </label>
+          <label class="inline_link-flex items-center">
+            <input
+              type="radio"
+              v-model="boarding_service"
+              :value="false"
+              class="form-radio"
+            />
+            <span class="ml-2">否</span>
+          </label>
+        </fieldset>
+
+        <!-- 住宿類型 -->
+        <div v-if="boarding_service" class="boarding_service-type-block">
+          <label class="boarding_service-type-label">寵物住宿類型</label>
+          <div class="boarding_service-type-checkboxes">
+            <label class="boarding_service-type-option">
+              <input type="checkbox" v-model="boarding_pet_type" value="狗狗" />
+              <span>狗狗</span>
+            </label>
+            <label class="boarding_service-type-option">
+              <input type="checkbox" v-model="boarding_pet_type" value="貓咪" />
+              <span>貓咪</span>
             </label>
           </div>
         </div>
 
-        <!-- 服務項目 -->
-        <div class="form-row">
-          <label class="field-label">服務項目</label>
-
-          <!-- 已選標籤 + 輸入框 -->
-          <div class="service-wrap">
-            <div class="service-input">
-              <!-- 已選標籤 -->
-              <span
-                v-for="(tag, i) in selectedServices"
-                :key="tag + i"
-                class="tag-chip"
-              >
-                {{ tag }}
-                <button type="button" class="tag-x" @click="removeService(i)">×</button>
-              </span>
-
-              <!-- 文字輸入（Enter 新增） -->
-              <input
-                v-model.trim="tagInput"
-                class="tag-text"
-                type="text"
-                placeholder="輸入服務並按 Enter"
-                @keydown.enter.prevent="addFromInput"
-              />
-            </div>
-          </div>
-
-          <!-- 建議清單（點一下加入） -->
-          <div class="service-suggest">
-            <button
-              v-for="s in serviceOptions"
-              :key="s"
-              type="button"
-              class="suggest-chip"
-              @click="addService(s)"
-              :disabled="selectedServices.includes(s)"
-            >
-              {{ s }}
-            </button>
-          </div>
+        <!-- 狗狗登記證 -->
+        <div
+          v-if="boarding_pet_type.includes('狗狗')"
+          class="license-upload-block"
+        >
+          <label class="license-label">狗狗特定寵物業登記許可證</label>
+          <button type="button" class="upload-btn">上傳狗狗證明</button>
         </div>
-  </section>
-    
-  
 
-    <!-- 交通 -->
-    <div>
-      <label class="block font-semibold mb-1">交通</label>
-      <input type="text" v-model="form.traffic" placeholder="例：捷運站步行5分鐘，附近有收費停車場" class="form-input w-full" />
-    </div>
+        <!-- 貓咪登記證 -->
+        <div
+          v-if="boarding_pet_type.includes('貓咪')"
+          class="license-upload-block"
+        >
+          <label class="license-label">貓咪特定寵物業登記許可證</label>
+          <button type="button" class="upload-btn">上傳貓咪證明</button>
+        </div>
+        <!-- 店家簡介 -->
+        <div>
+          <label class="block font-semibold mb-1">店家簡介</label>
+          <textarea
+            v-model="form.description"
+            rows="8"
+            placeholder="請輸入店家簡介內容"
+            class="form-textarea w-full"
+          ></textarea>
+        </div>
 
-    <!-- 接送、美容、住宿服務（你已完成） -->
-     <!-- 基本服務開關 -->
-    
-      <!-- 接送服務 -->
-      <fieldset class="space-y-2">
-        <legend class="font-semibold">接送服務</legend>
-        <label class="inline-flex items-center mr-4">
-          <input type="radio" v-model="pickup" :value="true" class="form-radio" />
-          <span class="ml-2">是</span>
-        </label>
-        <label class="inline-flex items-center">
-          <input type="radio" v-model="pickup" :value="false" class="form-radio" />
-          <span class="ml-2">否</span>
-        </label>
-      </fieldset>
+        <!-- line連結 -->
+        <div>
+          <label class="block font-semibold mb-1">line連結</label>
+          <input
+            type="url"
+            v-model.trim="form.line_link"
+            class="form-input w-full"
+          />
+        </div>
 
-      <!-- 美容服務 -->
-      <fieldset class="space-y-2">
-        <legend class="font-semibold">美容服務</legend>
-        <label class="inline-flex items-center mr-4">
-          <input type="radio" v-model="grooming" :value="true" class="form-radio" />
-          <span class="ml-2">是</span>
-        </label>
-        <label class="inline-flex items-center">
-          <input type="radio" v-model="grooming" :value="false" class="form-radio" />
-          <span class="ml-2">否</span>
-        </label>
-      </fieldset>
+        <!-- FB連結 -->
+        <div>
+          <label class="block font-semibold mb-1">FB連結</label>
+          <input
+            type="url"
+            v-model.trim="form.facebook_link"
+            class="form-input w-full"
+          />
+        </div>
 
-      <!-- 住宿服務 -->
-      <fieldset class="space-y-2">
-        <legend class="font-semibold">住宿服務</legend>
-        <label class="inline-flex items-center mr-4">
-          <input type="radio" v-model="boarding" :value="true" class="form-radio" />
-          <span class="ml-2">是</span>
-        </label>
-        <label class="inline-flex items-center">
-          <input type="radio" v-model="boarding" :value="false" class="form-radio" />
-          <span class="ml-2">否</span>
-        </label>
-      </fieldset>
-
-     <!-- 住宿類型 -->
-    <div v-if="boarding" class="boarding-type-block">
-      <label class="boarding-type-label">寵物住宿類型</label>
-      <div class="boarding-type-checkboxes">
-        <label class="boarding-type-option">
-          <input type="checkbox" v-model="boardingTypes" value="狗狗" />
-          <span>狗狗</span>
-        </label>
-        <label class="boarding-type-option">
-          <input type="checkbox" v-model="boardingTypes" value="貓咪" />
-          <span>貓咪</span>
-        </label>
-      </div>
-    </div>
-
-    <!-- 狗狗登記證 -->
-    <div v-if="boardingTypes.includes('狗狗')" class="license-upload-block">
-      <label class="license-label">狗狗特定寵物業登記許可證</label>
-      <button type="button" class="upload-btn">上傳狗狗證明</button>
-    </div>
-
-    <!-- 貓咪登記證 -->
-    <div v-if="boardingTypes.includes('貓咪')" class="license-upload-block">
-      <label class="license-label">貓咪特定寵物業登記許可證</label>
-      <button type="button" class="upload-btn">上傳貓咪證明</button>
-    </div>
-    <!-- 店家簡介 -->
-    <div>
-      <label class="block font-semibold mb-1">店家簡介</label>
-      <textarea v-model="form.description" rows="8" placeholder="請輸入店家簡介內容" class="form-textarea w-full"></textarea>
-    </div>
-
-    <!-- LINE連結 -->
-    <div>
-      <label class="block font-semibold mb-1">LINE連結</label>
-      <input type="url" v-model.trim="form.line" class="form-input w-full" placeholder="請提供官方LINE網址" />
-    </div>
-    
-    <!-- FB連結 -->
-    <div>
-      <label class="block font-semibold mb-1">FB連結</label>
-      <input type="url" v-model.trim="form.fb" class="form-input w-full" placeholder="請提供官方FB網址" />
-    </div>
-
-    <!-- google連結 -->
-    <div>
-      <label class="block font-semibold mb-1">Google地圖連結</label>
-      <input type="url" v-model.trim="form.google" class="form-input w-full" placeholder="請提供官方Google地圖網址" />
-    </div>    
-    <!-- 按鈕列 -->
-    </form>
-  </section>
+        <!-- google連結 -->
+        <div>
+          <label class="block font-semibold mb-1">Google地圖連結</label>
+          <input
+            type="url"
+            v-model.trim="form.google_map_link"
+            class="form-input w-full"
+          />
+        </div>
+        <!-- 按鈕列 -->
+      </form>
+    </section>
     <div class="flex justify-center pt-6 space-x-8">
-      <button class="btn" @click="router.push('/stores/info/manage')">取消並返回</button>
-      <button class="btn">確認修改</button>
+      <button class="btn" @click="router.push('/stores/info/manage')">
+        取消並返回
+      </button>
+      <button class="btn" @click="updateStoreInfo">確認修改</button>
     </div>
   </div>
 </template>

--- a/frontend/src/pages/Stores/Info/EditInfo.vue
+++ b/frontend/src/pages/Stores/Info/EditInfo.vue
@@ -273,6 +273,18 @@ onMounted(async () => {
     console.error("無法載入店家資訊：", error);
   }
 });
+
+// 確保 remove 函數正確定義並綁定
+const remove = (index) => {
+  if (index === 0) {
+    // 如果是封面圖片，清空封面
+    form.value.hero_image = null;
+  } else {
+    // 刪除對應的圖片
+    imagesToUpload.value.splice(index - 1, 1);
+  }
+  images.value.splice(index, 1);
+};
 </script>
 
 <template>

--- a/frontend/src/pages/Stores/Info/EditInfo.vue
+++ b/frontend/src/pages/Stores/Info/EditInfo.vue
@@ -201,6 +201,42 @@ const updateStoreInfo = async () => {
     alert("更新失敗，請稍後再試！");
   }
 };
+
+onMounted(async () => {
+  try {
+    const response = await api.get(`/store/profile/${userId.value}`);
+    const data = response.data;
+
+    // 填充表單資料
+    form.value.name = data.store_name || "";
+    form.value.address = data.address || {
+      county: "",
+      district: "",
+      detail: "",
+    };
+    form.value.phone = data.phone || "";
+    form.value.traffic_info = data.traffic_info || "";
+    form.value.description = data.description || "";
+    form.value.facebook_link = data.fb || "";
+    form.value.line_link = data.line || "";
+    form.value.google_map_link = data.google || "";
+
+    // 填充其他資料
+    pick_up_service.value = data.pick_up_service || false;
+    grooming_service.value = data.grooming_service || false;
+    boarding_service.value = data.boarding_service || false;
+    boarding_pet_type.value = data.boarding_pet_type || [];
+
+    daily_opening_time.value = data.daily_opening_time || "09 : 00";
+    daily_closing_hours.value = data.daily_closing_hours || "17 : 00";
+
+    selectedServices.value = data.service_item || [];
+
+    console.log("店家資訊已載入：", data);
+  } catch (error) {
+    console.error("無法載入店家資訊：", error);
+  }
+});
 </script>
 
 <template>

--- a/frontend/src/pages/Stores/Info/InfoManagement.vue
+++ b/frontend/src/pages/Stores/Info/InfoManagement.vue
@@ -40,6 +40,24 @@ const fetchStoreInfo = async () => {
 onMounted(fetchStoreInfo);
 
 const router = useRouter();
+
+const currentImageIndex = ref(0);
+
+const imagesList = computed(() => {
+  return (storesinfo.value.images || [])
+    .filter((img) => img && img.image_url) // 過濾掉空的
+    .map((img) => img.image_url); // 取出 URL
+});
+const showPreviousImage = () => {
+  currentImageIndex.value =
+    (currentImageIndex.value - 1 + imagesList.value.length) %
+    imagesList.value.length;
+};
+
+const showNextImage = () => {
+  currentImageIndex.value =
+    (currentImageIndex.value + 1) % imagesList.value.length;
+};
 </script>
 <template>
   <section class="store-section">
@@ -79,14 +97,41 @@ const router = useRouter();
     </div>
 
     <!-- 輪播圖 -->
-    <div class="store-carousel">
-      <!-- 模擬圖片區塊 -->
-      <div class="carousel-image"></div>
-      <div class="carousel-dots">
-        <span class="dot"></span>
-        <span class="dot"></span>
-        <span class="dot"></span>
+    <div class="store-carousel relative">
+      <div class="carousel-image">
+        <img
+          v-if="imagesList.length > 0"
+          :src="imagesList[currentImageIndex]"
+          alt="Carousel Image"
+          class="w-full h-full object-cover"
+        />
+        <p v-else>暫無圖片</p>
       </div>
+      <div
+        class="carousel-dots absolute bottom-2 left-1/2 transform -translate-x-1/2 flex gap-2"
+      >
+        <span
+          v-for="(image, index) in imagesList"
+          :key="index"
+          class="dot w-2 h-2 rounded-full"
+          :class="{
+            'bg-gray-800': index === currentImageIndex,
+            'bg-gray-400': index !== currentImageIndex,
+          }"
+        ></span>
+      </div>
+      <button
+        @click="showPreviousImage"
+        class="absolute left-2 top-1/2 transform -translate-y-1/2 bg-gray-800 text-white p-2 rounded-full"
+      >
+        &lt;
+      </button>
+      <button
+        @click="showNextImage"
+        class="absolute right-2 top-1/2 transform -translate-y-1/2 bg-gray-800 text-white p-2 rounded-full"
+      >
+        &gt;
+      </button>
     </div>
 
     <!-- 四格資訊 -->
@@ -135,12 +180,16 @@ const router = useRouter();
     <!-- icon 區塊：只要其中任何一個有值才顯示整區 -->
     <div
       class="store-social-icons flex items-center gap-4"
-      v-if="storesinfo.line || storesinfo.fb || storesinfo.google"
+      v-if="
+        storesinfo.line_link ||
+        storesinfo.facebook_link ||
+        storesinfo.google_map_link
+      "
     >
       <!-- _blank點擊連結時 在新分頁開啟網址 rel避免安全漏洞 -->
       <a
-        v-if="storesinfo.line"
-        :href="storesinfo.line"
+        v-if="storesinfo.line_link"
+        :href="storesinfo.line_link"
         target="_blank"
         rel="noopener"
         aria-label="LINE"
@@ -150,8 +199,8 @@ const router = useRouter();
       </a>
 
       <a
-        v-if="storesinfo.fb"
-        :href="storesinfo.fb"
+        v-if="storesinfo.facebook_link"
+        :href="storesinfo.facebook_link"
         target="_blank"
         rel="noopener"
         aria-label="Facebook"
@@ -161,8 +210,8 @@ const router = useRouter();
       </a>
 
       <a
-        v-if="storesinfo.google"
-        :href="storesinfo.google"
+        v-if="storesinfo.google_map_link"
+        :href="storesinfo.google_map_link"
         target="_blank"
         rel="noopener"
         aria-label="Google Maps"

--- a/frontend/src/pages/Stores/Info/InfoManagement.vue
+++ b/frontend/src/pages/Stores/Info/InfoManagement.vue
@@ -1,7 +1,45 @@
 <script setup>
-import { storesinfo } from '../../../data/storesinfo' // 路徑依你的專案結構調整
-import { useRouter } from 'vue-router'
-const router = useRouter()
+import { useRouter } from "vue-router";
+import { ref, computed, onMounted } from "vue";
+import api from "../../../api/api.js";
+
+const userId = ref(null);
+
+onMounted(async () => {
+  try {
+    const response = await api.get("/users/me");
+    userId.value = response.data.id;
+    // console.log("User ID fetched:", userId.value);
+  } catch (error) {
+    console.error("Error fetching user data:", error);
+  }
+});
+
+const storesinfo = ref({});
+
+const fetchStoreInfo = async () => {
+  try {
+    const response = await api.get(`/store/profile/${userId.value}`);
+    const data = response.data;
+
+    // Format time fields to remove seconds
+    if (data.daily_opening_time) {
+      data.daily_opening_time = data.daily_opening_time.slice(0, 5);
+    }
+    if (data.daily_closing_hours) {
+      data.daily_closing_hours = data.daily_closing_hours.slice(0, 5);
+    }
+
+    storesinfo.value = data;
+    console.log("Store info fetched:", storesinfo.value);
+  } catch (error) {
+    console.error("Error fetching store info:", error);
+  }
+};
+
+onMounted(fetchStoreInfo);
+
+const router = useRouter();
 </script>
 <template>
   <section class="store-section">
@@ -9,23 +47,35 @@ const router = useRouter()
     <div class="store-header">
       <h1 class="store-title">店家資訊</h1>
       <div class="store-actions">
-        <button class="btn-outline" @click="router.push('/stores/info/edit')">修改資料</button>
-        <button class="btn-black" @click="router.push('/stores/openservices')">變更服務</button>
+        <button class="btn-outline" @click="router.push('/stores/info/edit')">
+          修改資料
+        </button>
+        <button class="btn-black" @click="router.push('/stores/openservices')">
+          變更服務
+        </button>
       </div>
     </div>
     <!-- 店家審核狀態 -->
-    <h2 class="store-status"><FontAwesomeIcon :icon="['fas', 'sync-alt']" />
-    {{ storesinfo.status }}
+    <h2 class="store-status">
+      <FontAwesomeIcon :icon="['fas', 'sync-alt']" />
+      <span v-if="storesinfo.status === 'pending'">審核中</span>
+      <span v-else-if="storesinfo.status === 'confirmed'">已通過</span>
+      <span v-else-if="storesinfo.status === 'rechecked'">退回補件</span>
     </h2>
 
     <!-- 店名與地址 -->
     <div class="store-info">
-       <div class="flex flex-col md:flex-row md:justify-between md:items-center">
-      <h2 class="store-name"><FontAwesomeIcon :icon="['fas', 'circle']" />
-        {{ storesinfo.name }}</h2>
-      <p class="store-address"><FontAwesomeIcon :icon="['fas','location-dot']" class="mr-1" />
-      {{ storesinfo.address }}</p>
-       </div>
+      <div class="flex flex-col md:flex-row md:justify-between md:items-center">
+        <h2 class="store-name">
+          <FontAwesomeIcon :icon="['fas', 'circle']" />
+          {{ storesinfo.store_name }}
+        </h2>
+        <p class="store-address" v-if="storesinfo.address">
+          <FontAwesomeIcon :icon="['fas', 'location-dot']" class="mr-1" />
+          {{ storesinfo.address.county }}{{ storesinfo.address.district
+          }}{{ storesinfo.address.detail }}
+        </p>
+      </div>
     </div>
 
     <!-- 輪播圖 -->
@@ -47,28 +97,30 @@ const router = useRouter()
       </div>
       <div class="info-card">
         <h3 class="font-bold text-xl">營業時間</h3>
-        <p>{{ storesinfo.hours }}</p>
+        <p>
+          {{ storesinfo.daily_opening_time }} -
+          {{ storesinfo.daily_closing_hours }}
+        </p>
       </div>
       <div class="info-card">
         <h3 class="font-bold text-xl">有接送服務</h3>
-        <p>{{ storesinfo.pickup ? '提供專車接送服務' : '否' }}</p>
+        <p>{{ storesinfo.pick_up_service ? "有" : "否" }}</p>
       </div>
       <div class="info-card">
         <h3 class="font-bold text-xl">交通資訊</h3>
-        <p>{{ storesinfo.traffic }}</p>
+        <p>{{ storesinfo.traffic_info }}</p>
       </div>
     </div>
 
     <!-- 服務項目 -->
     <div class="store-services">
       <h3 class="section-subtitle font-bold text-xl">服務項目</h3>
-      <div class="service-tags">
-        <span class="tag">SPA護理</span>
-        <span class="tag">美容剪毛</span>
-        <span class="tag">住宿服務</span>
-        <span class="tag">寵物洗澡</span>
-        <span class="tag">寵物洗澡</span>
-        <span class="tag">寵物洗澡</span>
+      <div
+        v-for="service in storesinfo.service_item"
+        :key="service"
+        class="service-tags"
+      >
+        <span class="tag">{{ service }}</span>
       </div>
     </div>
 
@@ -76,48 +128,46 @@ const router = useRouter()
     <div class="store-description">
       <h3 class="section-subtitle font-bold text-xl mb-4">店家簡介</h3>
       <p>{{ storesinfo.description }}</p>
-
     </div>
 
-
- <!-- icon 區塊：只要其中任何一個有值才顯示整區 -->
+    <!-- icon 區塊：只要其中任何一個有值才顯示整區 -->
     <div
-  class="store-social-icons flex items-center gap-4"
-  v-if="storesinfo.line || storesinfo.fb || storesinfo.google"
->
-<!-- _blank點擊連結時 在新分頁開啟網址 rel避免安全漏洞 -->
-  <a
-    v-if="storesinfo.line"
-    :href="storesinfo.line"
-    target="_blank"  
-    rel="noopener"
-    aria-label="LINE"
-    class="icon"
-  >
-    <FontAwesomeIcon :icon="['fab', 'line']" class="text-green-500" />
-  </a>
+      class="store-social-icons flex items-center gap-4"
+      v-if="storesinfo.line || storesinfo.fb || storesinfo.google"
+    >
+      <!-- _blank點擊連結時 在新分頁開啟網址 rel避免安全漏洞 -->
+      <a
+        v-if="storesinfo.line"
+        :href="storesinfo.line"
+        target="_blank"
+        rel="noopener"
+        aria-label="LINE"
+        class="icon"
+      >
+        <FontAwesomeIcon :icon="['fab', 'line']" class="text-green-500" />
+      </a>
 
-  <a
-    v-if="storesinfo.fb"
-    :href="storesinfo.fb"
-    target="_blank"
-    rel="noopener"
-    aria-label="Facebook"
-    class="icon"
-  >
-    <FontAwesomeIcon :icon="['fab', 'facebook-f']" class="text-blue-600" />
-  </a>
+      <a
+        v-if="storesinfo.fb"
+        :href="storesinfo.fb"
+        target="_blank"
+        rel="noopener"
+        aria-label="Facebook"
+        class="icon"
+      >
+        <FontAwesomeIcon :icon="['fab', 'facebook-f']" class="text-blue-600" />
+      </a>
 
-  <a
-    v-if="storesinfo.google"
-    :href="storesinfo.google"
-    target="_blank"
-    rel="noopener"
-    aria-label="Google Maps"
-    class="icon"
-  >
-    <FontAwesomeIcon :icon="['fab', 'google']" class="text-red-500" />
-  </a>
-</div>
+      <a
+        v-if="storesinfo.google"
+        :href="storesinfo.google"
+        target="_blank"
+        rel="noopener"
+        aria-label="Google Maps"
+        class="icon"
+      >
+        <FontAwesomeIcon :icon="['fab', 'google']" class="text-red-500" />
+      </a>
+    </div>
   </section>
 </template>

--- a/frontend/src/pages/Stores/Info/InfoManagement.vue
+++ b/frontend/src/pages/Stores/Info/InfoManagement.vue
@@ -115,12 +115,14 @@ const router = useRouter();
     <!-- 服務項目 -->
     <div class="store-services">
       <h3 class="section-subtitle font-bold text-xl">服務項目</h3>
-      <div
-        v-for="service in storesinfo.service_item"
-        :key="service"
-        class="service-tags"
-      >
-        <span class="tag">{{ service }}</span>
+      <div class="service-tags-container flex flex-wrap justify-center gap-2">
+        <div
+          v-for="service in storesinfo.service_item"
+          :key="service"
+          class="service-tags"
+        >
+          <span class="tag">{{ service }}</span>
+        </div>
       </div>
     </div>
 

--- a/frontend/src/pages/Stores/Info/OpenServices.vue
+++ b/frontend/src/pages/Stores/Info/OpenServices.vue
@@ -1,13 +1,14 @@
 <script setup>
-import { ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { ref } from "vue";
+import { useRouter } from "vue-router";
+import api from "../../../api/api.js";
 
-const router = useRouter()
-const pickup = ref(true) //接送服務
-const grooming = ref(true) //美容服務
-const boarding = ref(false) //住宿服務
-const boardingTypes = ref([]) // 住宿類型
-const imageNote = ref('') // 圖片說明
+const router = useRouter();
+const pickup = ref(true); //接送服務
+const grooming = ref(true); //美容服務
+const boarding = ref(false); //住宿服務
+const boardingTypes = ref([]); // 住宿類型
+const imageNote = ref(""); // 圖片說明
 
 const submitForm = () => {
   console.log({
@@ -15,13 +16,13 @@ const submitForm = () => {
     grooming: grooming.value,
     boarding: boarding.value,
     boardingTypes: boardingTypes.value,
-    imageNote: imageNote.value
-  })
-}
+    imageNote: imageNote.value,
+  });
+};
 
 const handleCancel = () => {
-  router.push('/stores/info/manage')
-}
+  router.push("/stores/info/manage");
+};
 </script>
 
 <template>
@@ -95,8 +96,13 @@ const handleCancel = () => {
     </form>
 
     <!-- 登記證上傳：獨立卡片 -->
-    <section v-if="boardingTypes.includes('狗狗') || boardingTypes.includes('貓咪')" class="card mt-6">
-      <h2 class="section-subtitle">特定寵物業登記許可證 <span class="required">*</span></h2>
+    <section
+      v-if="boardingTypes.includes('狗狗') || boardingTypes.includes('貓咪')"
+      class="card mt-6"
+    >
+      <h2 class="section-subtitle">
+        特定寵物業登記許可證 <span class="required">*</span>
+      </h2>
 
       <div v-if="boardingTypes.includes('狗狗')" class="license-upload-block">
         <label class="license-label">狗狗特定寵物業登記許可證</label>
@@ -111,7 +117,9 @@ const handleCancel = () => {
 
     <!-- 按鈕列（在最底、容器內） -->
     <div class="btn-row">
-      <button type="button" class="btn btn-secondary" @click="handleCancel">取消並返回</button>
+      <button type="button" class="btn btn-secondary" @click="handleCancel">
+        取消並返回
+      </button>
       <button type="button" class="btn btn-primary">送出審核</button>
     </div>
   </div>


### PR DESCRIPTION
此 PR 對寵物預約平台的店家管理系統進行了多項優化與修正，涵蓋 後端 與 前端，包含提升圖片上傳數量限制、調整後端圖片更新邏輯，以及大幅優化前端店家資訊頁面（動態資料載入、更完善的 UI 與精準欄位對應）。同時，相關組件的 UI 一致性與程式碼維護性也獲得改善。

後端調整：
在 serializers.py 的 Meta.validate 方法中，將店家圖片上傳上限由 8 張 提高至 9 張。
優化 update 方法的圖片更新邏輯：更新店家資訊時，僅在有提供新圖片（JSON 或檔案上傳）時才刪除舊圖片，並同時正確處理 JSON 與檔案上傳兩種情況。

前端優化：
重構 InfoManagement.vue：
改為透過 API 動態取得店家與用戶資訊。
格式化時間欄位並精準對應後端欄位（如 store_name、address、service_item 等）。
店家狀態顯示更直覺化。
圖片輪播支援完整導覽與動態圓點指示器。
更新店家資訊卡片與社群圖示連結：
正確使用後端欄位與顯示邏輯（如 pick_up_service、traffic_info、line_link、facebook_link、google_map_link）。 

優化 OpenServices.vue 的程式風格與 UI 一致性：
改善格式排版、命名一致性。
更清晰的取消與送出按鈕行為處理。 