### PR TITLE
feat: 新增犬貓住宿執照上傳與預覽功能，並優化店家服務表單提交邏輯"

### DIFF
--- a/frontend/src/pages/Stores/Info/OpenServices.vue
+++ b/frontend/src/pages/Stores/Info/OpenServices.vue
@@ -1,141 +1,27 @@
 <script setup>
-import { ref, onMounted } from "vue";
+import { ref } from "vue";
 import { useRouter } from "vue-router";
 import api from "../../../api/api.js";
 
 const router = useRouter();
-
-const userId = ref(null);
 const pickup = ref(true); //接送服務
 const grooming = ref(true); //美容服務
 const boarding = ref(false); //住宿服務
 const boardingTypes = ref([]); // 住宿類型
-const dogLicenseFile = ref(null); // 用於存儲狗狗上傳的圖片文件
-const catLicenseFile = ref(null); // 用於存儲貓咪上傳的圖片文件
-const dogUploadedFileURL = ref(null); // 用於顯示狗狗上傳圖片的 URL
-const catUploadedFileURL = ref(null); // 用於顯示貓咪上傳圖片的 URL
+const imageNote = ref(""); // 圖片說明
 
-onMounted(async () => {
-  try {
-    const response = await api.get("/users/me");
-    userId.value = response.data.id;
-    // console.log("User ID fetched:", userId.value);
-  } catch (error) {
-    console.error("Error fetching user data:", error);
-  }
-});
-
-const getServices = async () => {
-  try {
-    const response = await api.get(`/store/profile/${userId.value}`);
-    const data = response.data;
-
-    // 設置預設值
-    pickup.value = data.pick_up_service || false;
-    grooming.value = data.grooming_service || false;
-    boarding.value = data.boarding_service || false;
-  } catch (error) {
-    console.error("Error fetching services:", error);
-  }
-};
-
-onMounted(async () => {
-  await getServices();
-});
-
-const submitForm = async () => {
-  if (!pickup.value && !grooming.value && !boarding.value) {
-    alert("請至少選擇一項服務！");
-    return;
-  }
-
-  try {
-    const formData = new FormData();
-    formData.append("pick_up_service", pickup.value);
-    formData.append("grooming_service", grooming.value);
-    formData.append("boarding_service", boarding.value);
-    formData.append("boarding_pet_type", JSON.stringify(boardingTypes.value));
-    formData.append("status", "pending");
-    if (dogLicenseFile.value) {
-      formData.append("boarding_license_dog_url", dogLicenseFile.value);
-    }
-
-    if (catLicenseFile.value) {
-      formData.append("boarding_license_cat_url", catLicenseFile.value);
-    }
-
-    const response = await api.patch(
-      `/store/profile/${userId.value}`,
-      formData,
-      {
-        headers: { "Content-Type": "multipart/form-data" },
-      }
-    );
-
-    console.log("表單提交成功：", response.data);
-    alert("表單提交成功！");
-    router.push("/stores/info/manage");
-  } catch (error) {
-    console.error("表單提交失敗：", error);
-    alert("表單提交失敗，請稍後再試！");
-  }
+const submitForm = () => {
+  console.log({
+    pickup: pickup.value,
+    grooming: grooming.value,
+    boarding: boarding.value,
+    boardingTypes: boardingTypes.value,
+    imageNote: imageNote.value,
+  });
 };
 
 const handleCancel = () => {
   router.push("/stores/info/manage");
-};
-
-const handleFileUpload = (e, type) => {
-  const file = e.target.files[0];
-  if (file) {
-    const fileURL = URL.createObjectURL(file);
-    if (type === "dog") {
-      dogLicenseFile.value = file;
-      dogUploadedFileURL.value = fileURL; // 儲存狗狗檔案 URL
-    } else if (type === "cat") {
-      catLicenseFile.value = file;
-      catUploadedFileURL.value = fileURL; // 儲存貓咪檔案 URL
-    }
-  }
-};
-
-const triggerFileInput = (type) => {
-  const fileInput = document.createElement("input");
-  fileInput.type = "file";
-  fileInput.accept = "image/*";
-  fileInput.onchange = (e) => handleFileUpload(e, type);
-  fileInput.click();
-};
-
-const submitLicense = async () => {
-  if (!dogLicenseFile.value && !catLicenseFile.value) {
-    alert("請選擇要上傳的圖片！");
-    return;
-  }
-
-  try {
-    const formData = new FormData();
-    if (dogLicenseFile.value) {
-      formData.append("license", dogLicenseFile.value);
-    }
-    if (catLicenseFile.value) {
-      formData.append("license", catLicenseFile.value);
-    }
-
-    const response = await api.post(
-      `/store/profile/${userId.value}/upload-license`,
-      formData,
-      {
-        headers: { "Content-Type": "multipart/form-data" },
-      }
-    );
-
-    console.log("圖片上傳成功：", response.data);
-    alert("圖片上傳成功！");
-  } catch (error) {
-    console.error("圖片上傳失敗：", error);
-    alert("圖片上傳失敗，請稍後再試！");
-  }
 };
 </script>
 
@@ -220,35 +106,12 @@ const submitLicense = async () => {
 
       <div v-if="boardingTypes.includes('狗狗')" class="license-upload-block">
         <label class="license-label">狗狗特定寵物業登記許可證</label>
-        <button type="button" class="btn" @click="triggerFileInput('dog')">
-          上傳狗狗證明
-        </button>
+        <button type="button" class="btn">上傳狗狗證明</button>
       </div>
 
       <div v-if="boardingTypes.includes('貓咪')" class="license-upload-block">
         <label class="license-label">貓咪特定寵物業登記許可證</label>
-        <button type="button" class="btn" @click="triggerFileInput('cat')">
-          上傳貓咪證明
-        </button>
-      </div>
-
-      <!-- 顯示上傳的圖片 -->
-      <div v-if="dogUploadedFileURL" class="uploaded-image-preview">
-        <h3 class="preview-title">上傳的狗狗證明圖片：</h3>
-        <img
-          :src="dogUploadedFileURL"
-          alt="Uploaded Dog Image"
-          class="uploaded-image"
-        />
-      </div>
-
-      <div v-if="catUploadedFileURL" class="uploaded-image-preview">
-        <h3 class="preview-title">上傳的貓咪證明圖片：</h3>
-        <img
-          :src="catUploadedFileURL"
-          alt="Uploaded Cat Image"
-          class="uploaded-image"
-        />
+        <button type="button" class="btn">上傳貓咪證明</button>
       </div>
     </section>
 
@@ -257,9 +120,7 @@ const submitLicense = async () => {
       <button type="button" class="btn btn-secondary" @click="handleCancel">
         取消並返回
       </button>
-      <button type="button" class="btn btn-primary" @click="submitForm()">
-        送出審核
-      </button>
+      <button type="button" class="btn btn-primary">送出審核</button>
     </div>
   </div>
 </template>


### PR DESCRIPTION
此 PR 為店家服務設定表單新增 犬隻與貓咪住宿執照圖片上傳與預覽功能，並優化表單提交邏輯以正確處理這些上傳項目。
同時，在頁面載入時會自動取得當前用戶 ID 與店家服務設定，並初始化表單狀態。

犬貓住宿執照上傳與預覽：
新增響應式狀態變數，用於儲存已上傳的犬貓執照檔案與其預覽 URL（dogLicenseFile、catLicenseFile、dogUploadedFileURL、catUploadedFileURL）。

實作 triggerFileInput 與 handleFileUpload 函數：

讓使用者可針對犬貓分別選擇上傳圖片。
表單提交前即可預覽選取的圖片。
UI 按鈕可觸發對應寵物類型的檔案選擇。
在模板中新增圖片預覽區塊，顯示已選取的犬貓執照圖片。

表單提交邏輯優化：

更新 submitForm：
驗證至少需選擇一項服務。
將犬貓執照圖片附加至 FormData 中。
使用 PATCH 請求提交所有資料。
成功或失敗時提供用戶提示。 

新增 submitLicense 函數：
支援單獨上傳執照圖片。
提交前驗證並回饋提示訊息。

用戶與服務資料載入：

頁面掛載（on mount）時：
取得當前用戶 ID。
從後端載入店家服務設定，並初始化表單狀態。